### PR TITLE
Fix ongoing 500s and broken homepage search links by updating target organism search .to match new schema.

### DIFF
--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -58,7 +58,7 @@ def search_score_sets(db: Session, owner: Optional[User], search: ScoreSetsSearc
                 ScoreSet.keyword_objs.any(func.lower(Keyword.text).contains(lower_search_text)),
                 ScoreSet.target_genes.any(
                     TargetGene.target_sequence.has(
-                        TargetSequence.reference.has(ReferenceGenome.organism_name.in_(search.target_organism_names))
+                        TargetSequence.reference.has(func.lower(ReferenceGenome.organism_name).contains(lower_search_text))
                     )
                 ),
                 # TODO(#94): add UNIPROT, ENSEMBL, REFSEQ, LICENSE, plus TAX_ID if numeric

--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -58,7 +58,9 @@ def search_score_sets(db: Session, owner: Optional[User], search: ScoreSetsSearc
                 ScoreSet.keyword_objs.any(func.lower(Keyword.text).contains(lower_search_text)),
                 ScoreSet.target_genes.any(
                     TargetGene.target_sequence.has(
-                        TargetSequence.reference.has(func.lower(ReferenceGenome.organism_name).contains(lower_search_text))
+                        TargetSequence.reference.has(
+                            func.lower(ReferenceGenome.organism_name).contains(lower_search_text)
+                        )
                     )
                 ),
                 # TODO(#94): add UNIPROT, ENSEMBL, REFSEQ, LICENSE, plus TAX_ID if numeric

--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -25,6 +25,7 @@ from mavedb.models.reference_genome import ReferenceGenome
 from mavedb.models.score_set import ScoreSet
 from mavedb.models.target_accession import TargetAccession
 from mavedb.models.target_gene import TargetGene
+from mavedb.models.target_sequence import TargetSequence
 from mavedb.models.user import User
 from mavedb.view_models.search import ScoreSetsSearch
 
@@ -55,7 +56,12 @@ def search_score_sets(db: Session, owner: Optional[User], search: ScoreSetsSearc
                 ScoreSet.target_genes.any(func.lower(TargetGene.name).contains(lower_search_text)),
                 ScoreSet.target_genes.any(func.lower(TargetGene.category).contains(lower_search_text)),
                 ScoreSet.keyword_objs.any(func.lower(Keyword.text).contains(lower_search_text)),
-                # TODO Add: ORGANISM_NAME UNIPROT, ENSEMBL, REFSEQ, LICENSE, plus TAX_ID if numeric
+                ScoreSet.target_genes.any(
+                    TargetGene.target_sequence.has(
+                        TargetSequence.reference.has(ReferenceGenome.organism_name.in_(search.target_organism_names))
+                    )
+                ),
+                # TODO(#94): add UNIPROT, ENSEMBL, REFSEQ, LICENSE, plus TAX_ID if numeric
                 ScoreSet.publication_identifiers.any(
                     func.lower(PublicationIdentifier.identifier).contains(lower_search_text)
                 ),
@@ -82,7 +88,9 @@ def search_score_sets(db: Session, owner: Optional[User], search: ScoreSetsSearc
     if search.target_organism_names:
         query = query.filter(
             ScoreSet.target_genes.any(
-                TargetGene.reference.any(ReferenceGenome.organism_name.in_(search.target_organism_names))
+                TargetGene.target_sequence.has(
+                    TargetSequence.reference.has(ReferenceGenome.organism_name.in_(search.target_organism_names))
+                )
             )
         )
 


### PR DESCRIPTION
This PR both changes the currently broken target_organism_names search, which is creating 500s/alerts, and also adds target_organism_names search to the top-level search, which fixes the Homo sapiens etc. links on the homepage (https://github.com/VariantEffect/mavedb-ui/issues/64).