### PR TITLE
Fix experiment URN generation logic to find max suffix among existing experiments.

### DIFF
--- a/src/mavedb/lib/urns.py
+++ b/src/mavedb/lib/urns.py
@@ -84,7 +84,7 @@ def generate_experiment_urn(db: Session, experiment_set: ExperimentSet, experime
         max_suffix = None
         for experiment in published_experiments_query:
             suffix = re.search(f"^{re.escape(experiment_set.urn)}-([a-z]+)$", experiment.urn).group(1)
-            if suffix and (max_suffix is None or len(max_suffix) < len(experiment.urn) or max_suffix < suffix):
+            if suffix and (max_suffix is None or len(max_suffix) < len(suffix) or max_suffix < suffix):
                 max_suffix = suffix
         if max_suffix is None:
             next_suffix = "a"


### PR DESCRIPTION
Fixes #97.

Demo of bad behavior (also linked from the issue): https://colab.research.google.com/drive/1W_iEt7Acj94iYUcrF9qz3bYsQ0RXuAwN