### PR TITLE
Ensure accession/sequence Target Models Match DB

### DIFF
--- a/src/mavedb/models/target_accession.py
+++ b/src/mavedb/models/target_accession.py
@@ -9,7 +9,7 @@ from mavedb.db.base import Base
 class TargetAccession(Base):
     __tablename__ = "target_accessions"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True)
     assembly = Column(String, nullable=True)
     accession = Column(String, nullable=False)
     gene = Column(String, nullable=True)

--- a/src/mavedb/models/target_sequence.py
+++ b/src/mavedb/models/target_sequence.py
@@ -14,7 +14,7 @@ class TargetSequence(Base):
     sequence_type = Column(String, nullable=False)
     sequence = Column(String, nullable=False)
     label = Column(String, nullable=True)
-    reference_id = Column("reference_id", Integer, ForeignKey("reference_genomes.id"), nullable=False)
+    reference_id = Column("reference_id", Integer, ForeignKey("reference_genomes.id"), nullable=True)
     reference = relationship(
         "ReferenceGenome",
         backref=backref("target_sequences", single_parent=True),


### PR DESCRIPTION
Alembic changes that did not match the defined models created alembic drift that causes the `--autogenerate` command to create unnecessary revisions. Removing the index on the TargetAccession `id` column and making the TargetSequence `reference_id` column nullable should remedy this drift.