### PR TITLE
Expand Genomic Scoreset Transcript Pool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,40 @@
+FROM python:3.9 AS downloader
+
+WORKDIR /data
+
+# Install tools necessary used to install samtools and htslib so we can configure fasta files for genomic assembly.
+RUN apt-get update && apt-get install -y \
+	build-essential \
+	curl \
+	git \
+	libbz2-dev \
+	libcurl4-openssl-dev \
+	libgsl0-dev \
+	liblzma-dev \
+	libncurses5-dev \
+	libperl-dev \
+	libssl-dev \
+	zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install samtools and htslib.
+ARG htsversion=1.19
+RUN curl -L https://github.com/samtools/htslib/releases/download/${htsversion}/htslib-${htsversion}.tar.bz2 | tar xj && \
+    (cd htslib-${htsversion} && ./configure --enable-plugins --with-plugin-path='$(libexecdir)/htslib:/usr/libexec/htslib' && make install) && \
+    ldconfig && \
+    curl -L https://github.com/samtools/samtools/releases/download/${htsversion}/samtools-${htsversion}.tar.bz2 | tar xj && \
+    (cd samtools-${htsversion} && ./configure --with-htslib=system && make install) && \
+    curl -L https://github.com/samtools/bcftools/releases/download/${htsversion}/bcftools-${htsversion}.tar.bz2 | tar xj && \
+    (cd bcftools-${htsversion} && ./configure --enable-libgsl --enable-perl-filters --with-htslib=system && make install)
+
+# Fetch and index GRCh37 and GRCh38 assemblies. These will augment seqrepo transcript sequences.
+RUN wget -O - https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_genomic.fna.gz | gzip -d | bgzip >  GCF_000001405.25_GRCh37.p13_genomic.fna.gz
+RUN wget -O - https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCF_000001405.39_GRCh38.p13/GCF_000001405.39_GRCh38.p13_genomic.fna.gz | gzip -d | bgzip > GCF_000001405.39_GRCh38.p13_genomic.fna.gz
+RUN samtools faidx GCF_000001405.25_GRCh37.p13_genomic.fna.gz
+RUN samtools faidx GCF_000001405.39_GRCh38.p13_genomic.fna.gz
+
 FROM python:3.9
+COPY --from=downloader /data /data
 
 WORKDIR /code
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic~=1.7.6
 authlib~=0.15.5
 biocommons~=0.0.0
+cdot~=0.2.21
 celery~=5.2.3
 cryptography~=37.0.4
 eutils~=0.6.0

--- a/src/mavedb/deps.py
+++ b/src/mavedb/deps.py
@@ -2,6 +2,7 @@
 import sys
 from typing import Generator
 
+from cdot.hgvs.dataproviders import RESTDataProvider, ChainedSeqFetcher, FastaSeqFetcher, SeqFetcher
 from sqlalchemy.dialects.postgresql import JSONB as POSTGRES_JSONB
 from sqlalchemy.types import JSON
 
@@ -15,6 +16,16 @@ def get_db() -> Generator:
         yield db
     finally:
         db.close()
+
+
+def hgvs_data_provider() -> Generator:
+    grch38_fetcher = FastaSeqFetcher("/data/GCF_000001405.39_GRCh38.p13_genomic.fna.gz")
+    grch37_fetcher = FastaSeqFetcher("/data/GCF_000001405.25_GRCh37.p13_genomic.fna.gz")
+
+    # Prioritize fetching from SeqRepo, then GRCh38, then GRCh37.
+    seqfetcher = ChainedSeqFetcher(SeqFetcher(), grch38_fetcher, grch37_fetcher)
+
+    yield RESTDataProvider(seqfetcher=seqfetcher)
 
 
 # if 'PYTEST_RUN_CONFIG' in os.environ:

--- a/src/mavedb/lib/validation/dataframe.py
+++ b/src/mavedb/lib/validation/dataframe.py
@@ -1,17 +1,16 @@
 from typing import Optional, Tuple, Union
 
-import hgvs.dataproviders.interface
-import hgvs.dataproviders.seqfetcher
-import hgvs.dataproviders.uta
 import hgvs.exceptions
 import hgvs.parser
 import hgvs.validator
 import numpy as np
 import pandas as pd
+
 from fqfa.util.translate import translate_dna
 from mavehgvs.exceptions import MaveHgvsParseError
 from mavehgvs.variant import Variant
 
+from mavedb.deps import hgvs_data_provider
 from mavedb.lib.exceptions import MixedTargetError
 from mavedb.lib.validation.constants.general import (
     hgvs_nt_column,
@@ -481,7 +480,7 @@ def validate_hgvs_genomic_column(column: pd.Series, is_index: bool, targets: lis
             raise ValueError(f"unrecognized hgvs column name '{column.name}'")
 
     hp = hgvs.parser.Parser()
-    hdp = hgvs.dataproviders.uta.connect()
+    hdp = hgvs_data_provider()
     vr = hgvs.validator.Validator(hdp=hdp)
 
     invalid_variants = list()

--- a/src/mavedb/routers/hgvs.py
+++ b/src/mavedb/routers/hgvs.py
@@ -1,14 +1,14 @@
 from itertools import chain
 from typing import Any, Union
 
-import bioutils.assemblies
-import hgvs
-import hgvs.dataproviders.interface
-import hgvs.dataproviders.seqfetcher
 import hgvs.dataproviders.uta
-import hgvs.parser
-import hgvs.validator
-from fastapi import APIRouter, HTTPException
+import bioutils.assemblies
+
+from cdot.hgvs.dataproviders import RESTDataProvider
+from fastapi import APIRouter, Depends, HTTPException
+from hgvs import parser, validator
+
+from mavedb.deps import hgvs_data_provider
 
 router = APIRouter(
     prefix="/api/v1/hgvs",
@@ -18,24 +18,24 @@ router = APIRouter(
 
 
 @router.get("/fetch/{accession}", status_code=200, response_model=Any)
-def hgvs_fetch(accession: str) -> Any:
+def hgvs_fetch(accession: str, hdp: RESTDataProvider = Depends(hgvs_data_provider)) -> Any:
     """
     List stored sequences
     """
-    return hgvs.dataproviders.uta.connect().seqfetcher.fetch_seq(accession)
+    return hdp.seqfetcher.fetch_seq(accession)
 
 
 @router.post("/validate", status_code=200, response_model=Any)
-def hgvs_validate(variant: dict[str, str]) -> Any:
+def hgvs_validate(variant: dict[str, str], hdp: RESTDataProvider = Depends(hgvs_data_provider)) -> Any:
     """
-    List stored sequences
+    Validate a provided variant
     """
-    hp = hgvs.parser.Parser()
-    hdp = hgvs.dataproviders.uta.connect()
+    hp = parser.Parser()
+    variant = hp.parse(variant["variant"])
 
     try:
-        valid = hgvs.validator.Validator(hdp=hdp).validate(hp.parse(variant["variant"]), strict=False)
-    except hgvs.validator.HGVSInvalidVariantError as e:
+        valid = validator.Validator(hdp=hdp).validate(variant, strict=False)
+    except validator.HGVSInvalidVariantError as e:
         raise HTTPException(400, str(e))
     else:
         return valid
@@ -71,37 +71,50 @@ def list_assemblies_grouped() -> Any:
 
 
 @router.get("/{assembly}/accessions", status_code=200, response_model=list)
-def list_accessions(assembly: str) -> Any:
+def list_accessions(assembly: str, hdp: RESTDataProvider = Depends(hgvs_data_provider)) -> Any:
     """
     List stored accessions
     """
-    return list(hgvs.dataproviders.uta.connect().get_assembly_map(assembly_name=assembly).keys())
+    return list(hdp.get_assembly_map(assembly_name=assembly).keys())
 
 
 @router.get("/genes", status_code=200, response_model=list)
 def list_genes():
+    """
+    List stored genes
+    """
+    # Even though it doesn't provide the most complete transcript pool, UTA does provide more direct
+    # access to a complete list of genes which have transcript information available.
     return list(chain.from_iterable(hgvs.dataproviders.uta.connect()._fetchall("select hgnc from gene")))
 
 
 @router.get("/genes/{gene}", status_code=200, response_model=list)
-def gene_info(gene: str):
-    return hgvs.dataproviders.uta.connect().get_gene_info(gene)
+def gene_info(gene: str, hdp: RESTDataProvider = Depends(hgvs_data_provider)):
+    """
+    List stored gene information for a specified gene
+    """
+    return hdp.get_gene_info(gene)
 
 
 @router.get("/transcripts/gene/{gene}", status_code=200, response_model=list)
-def list_transcripts_for_gene(gene: str):
-    # the 4th element of each tx_info list is the accession number for the transcript. Only
-    # surface unique elements
-    return set([tx_info[3] for tx_info in hgvs.dataproviders.uta.connect().get_tx_for_gene(gene)])
+def list_transcripts_for_gene(gene: str, hdp: RESTDataProvider = Depends(hgvs_data_provider)):
+    """
+    List transcripts associated with a particular gene
+    """
+    return set([tx_info["tx_ac"] for tx_info in hdp.get_tx_for_gene(gene)])
 
 
 @router.get("/transcripts/{transcript}", status_code=200, response_model=list)
-def transcript_info(transcript: str):
-    # the 4th element of each tx_info list is the accession number for the transcript. Only
-    # surface unique elements
-    return hgvs.dataproviders.uta.connect().get_tx_identity_info(transcript)
+def transcript_info(transcript: str, hdp: RESTDataProvider = Depends(hgvs_data_provider)):
+    """
+    List transcript information for a particular transcript
+    """
+    return hdp.get_tx_identity_info(transcript)
 
 
 @router.get("/transcripts/protein/{transcript}", status_code=200, response_model=str)
-def convert_to_protein(transcript: str):
-    return hgvs.dataproviders.uta.connect().get_pro_ac_for_tx_ac(transcript)
+def convert_to_protein(transcript: str, hdp: RESTDataProvider = Depends(hgvs_data_provider)):
+    """
+    Convert a provided transcript from it's nucleotide accession identifier to its protein accession identifier
+    """
+    return hdp.get_pro_ac_for_tx_ac(transcript)


### PR DESCRIPTION
- Uses the CDOT package to fetch transcript sequences instead of built-in biocommons UTA methods in order to expand our pool of scoresets.
- Adds both samtools and htslib to our Docker image. These tools are used to index the GRCh37 and GRCh38 genome builds that CDOT relies on for sequence fetching of the expanded transcript pool.
- Adds a new dep `hgvs_data_provider`. This dep exposes a `RESTDataProvider` that provides access to our expanded seqpool. An instance of `ChainedSeqFetcher` is used by this object, which will default to fetching sequences from SeqRepo if they exist, but fall back on the new GRCh37 and GRCh38 data if no sequence matching the transcript exists in SeqRepo.
- This new dep is used wherever we previously accessed biocommons HGVS to ensure we always use the same pool of transcripts and sequences.