### PR TITLE
Nick/add GitHub CI for Python 3.9

### DIFF
--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -3,6 +3,19 @@ on:
   push:
 
 jobs:
+  run-tests-3_9:
+    runs-on: ubuntu-20.04
+    name: Pytest on Python 3.9 / Ubuntu 20.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+        cache: 'pip'
+    - run: pip install --upgrade pip
+    - run: pip install .[dev,server]
+    - run: pytest tests/
+
   run-tests-3_10:
     runs-on: ubuntu-latest
     name: Pytest on Python 3.10


### PR DESCRIPTION
I noticed we have Python 3.9 in the Dockerfile still so I've added a Python 3.9 version to the github CI actions so we're actually testing on the version we're using ... 