### PR TITLE
Nick dependabot alerts (attempt 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,20 +39,21 @@ dev = [
     "pre-commit",
     "pytest~=7.0.1",
     "jsonschema",
+    "httpx~=0.26.0",
 ]
 server = [
     "alembic~=1.7.6",
     "authlib~=0.15.5",
-    "cryptography~=37.0.4",
+    "cryptography~=41.0.6",
     "celery~=5.2.3",
-    "fastapi~=0.71.0",
+    "fastapi~=0.95.0",
     "orcid~=1.0.3",
     "psycopg2~=2.9.3",
     "python-jose[cryptography]~=3.3.0",
     "python-multipart~=0.0.5",
-    "requests~=2.28.1",
+    "requests~=2.31.0",
     "slack-sdk~=3.21.3",
-    "starlette~=0.17.1",
+    "starlette~=0.27.0",
     "uvicorn[standard]",
 ]
 


### PR DESCRIPTION
Dependabot identified starlette 0.27.0 as the minimum required:
https://github.com/VariantEffect/mavedb-api/security/dependabot/6

The earliest version of fastapi compatible is fastapi~=0.95.2

Explicitly installing httpx is required by starlette testclient so I've added that to dev dependencies as well.

Rework of #124 / #129