### PR TITLE
Add more info to exception handler

### DIFF
--- a/src/mavedb/server_main.py
+++ b/src/mavedb/server_main.py
@@ -127,9 +127,10 @@ def customize_validation_error(error):
 def find_traceback_locations():
     _, _, tb = sys.exc_info()
     return [
-        f"{fs.filename}:{fs.lineno}:{fs.name}"
+        (fs.filename, fs.lineno, fs.name)
         for fs in traceback.extract_tb(tb)
-        if not fs.filename.startswith("/usr/") # Attempt to not show many layers of library code
+        # attempt to show only *our* code, not the many layers of library code
+        if "/mavedb/" in fs.filename and "/.direnv/" not in fs.filename
     ]
 
 

--- a/src/mavedb/server_main.py
+++ b/src/mavedb/server_main.py
@@ -129,7 +129,7 @@ def find_traceback_locations():
     return [
         f"{fs.filename}:{fs.lineno}:{fs.name}"
         for fs in traceback.extract_tb(tb)
-        if not fs.filename.startswith("/usr/")
+        if not fs.filename.startswith("/usr/") # Attempt to not show many layers of library code
     ]
 
 

--- a/src/mavedb/server_main.py
+++ b/src/mavedb/server_main.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import sys
+import traceback
 
 import uvicorn
 from fastapi import FastAPI
@@ -122,31 +124,44 @@ def customize_validation_error(error):
     return error
 
 
-def exception_as_dict(ex):
-    return dict(
-        type=ex.__class__.__name__,
-        exception=str(ex),
-    )
+def find_traceback_locations():
+    _, _, tb = sys.exc_info()
+    return [
+        f"{fs.filename}:{fs.lineno}:{fs.name}"
+        for fs in traceback.extract_tb(tb)
+        if not fs.filename.startswith("/usr/")
+    ]
 
 
 @app.exception_handler(Exception)
 async def exception_handler(request, err):
     logger.error("Uncaught exception", exc_info=err)
+
+    text = json.dumps({
+        "type": err.__class__.__name__,
+        "exception": str(err),
+        "location": find_traceback_locations(),
+        "client": str(request.client.host),
+        "request": f"{request.method} {request.url}",
+    })
+
     slack_webhook_url = os.getenv("SLACK_WEBHOOK_URL")
     if slack_webhook_url is not None and len(slack_webhook_url) > 0:
         client = WebhookClient(url=slack_webhook_url)
         response = client.send(
-            text=json.dumps(exception_as_dict(err)),
+            text=text,
             blocks=[
                 {
                     "type": "section",
                     "text": {
                         "type": "plain_text",
-                        "text": json.dumps(exception_as_dict(err)),
+                        "text": text
                     },
                 }
             ],
         )
+    else:
+        print(f"EXCEPTION_HANDLER: {text}")
     return JSONResponse(status_code=500, content={"message": "Internal server error"})
 
 


### PR DESCRIPTION
adds "location", "client" and "request" fields to the messages we forward to slack when a 500 server error occurs, like:

```
{
    "type": "ValueError",
    "exception": "Assembly 'undefined' not supported. Supported assemblies: GRCh37, GRCh38",
    "location": ["/code/src/mavedb/routers/hgvs.py:78:list_accessions"],
    "client": "192.168.251.1",
    "request": "GET http://localhost:8002/api/v1/hgvs/undefined/accessions"
}
```

see also #134 