### PR TITLE
Add an apt-get clean step to the Dockerfile to slow Docker builder cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9 AS downloader
 WORKDIR /data
 
 # Install tools necessary used to install samtools and htslib so we can configure fasta files for genomic assembly.
-RUN apt-get update && apt-get install -y \
+RUN apt-get clean && apt-get update && apt-get install -y \
 	build-essential \
 	curl \
 	git \


### PR DESCRIPTION
…che accumulation on Mac builds.

see issue #142 for context.