### PR TITLE
Debug current version of score set

### DIFF
--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -55,6 +55,14 @@ def search_score_sets(db: Session, owner: Optional[User], search: ScoreSetsSearc
     query = db.query(ScoreSet)  # \
     # .filter(ScoreSet.private.is_(False))
 
+    # Get superseded_score_set_id list
+    replaced_score_set_ids = db.query(ScoreSet.superseded_score_set_id).filter(ScoreSet.superseded_score_set_id.isnot(None)).distinct().all()
+    replaced_score_set_ids = {id for (id,) in replaced_score_set_ids}
+
+    #  filter out the score sets that are replaced by other score sets
+    if replaced_score_set_ids:
+        query = query.filter(~ScoreSet.id.in_(replaced_score_set_ids))
+
     if owner is not None:
         query = query.filter(ScoreSet.created_by_id == owner.id)
 

--- a/src/mavedb/routers/score_sets.py
+++ b/src/mavedb/routers/score_sets.py
@@ -125,6 +125,32 @@ async def show_score_set(
 
     return await fetch_score_set_by_urn(db, urn, user)
 
+@router.get(
+    "/score-sets/current-version/{urn}",
+    status_code=200,
+    response_model=Optional[score_set.ScoreSet],
+    responses={404: {}, 500: {}},
+    response_model_exclude_none=True,
+)
+async def get_score_set_current_version(
+    *, urn: str, db: Session = Depends(deps.get_db), user: User = Depends(get_current_user)
+) -> Any:
+    """
+    Fetch the newest version of a score set by URN.
+    """
+
+    item = await fetch_score_set_by_urn(db, urn, user)
+    if item:
+        score_set_id = item.id
+        while score_set_id:
+            permission_filter = ScoreSet.private.is_(False)
+            superseding_score_set = db.query(ScoreSet).filter(ScoreSet.superseded_score_set_id == score_set_id).filter(permission_filter).one_or_none()
+            if superseding_score_set:
+                score_set_id = superseding_score_set.id
+                item = superseding_score_set
+            else:
+                break
+    return item
 
 @router.get(
     "/score-sets/{urn}/scores",

--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -198,8 +198,7 @@ class SavedScoreSet(ScoreSetBase):
     num_variants: int
     experiment: SavedExperiment
     license: ShortLicense
-    superseded_score_set_urn: Optional[str]
-    superseding_score_set_urn: Optional[str]
+    superseded_score_set_id: Optional[int]
     meta_analyzes_score_set_urns: list[str]
     meta_analyzed_by_score_set_urns: list[str]
     doi_identifiers: Sequence[SavedDoiIdentifier]


### PR DESCRIPTION
Current version means this score set is the newest. None of any other score set supersedes it. `replaces_id` of `score_set` only records the superseded score set ID.

Solve https://github.com/VariantEffect/mavedb-ui/issues/75 problem. 