### PR TITLE
Bugfix: Possible to Create Score Sets with No Targets

### DIFF
--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -106,7 +106,7 @@ class ScoreSetModify(ScoreSetBase):
     @validator("target_genes")
     def at_least_one_target_gene_exists(cls, field_value, values):
         if len(field_value) < 1:
-            raise ValidationError("Score sets should define at least one target gene.")
+            raise ValidationError("Score sets should define at least one target.")
 
         return field_value
 

--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -108,6 +108,8 @@ class ScoreSetModify(ScoreSetBase):
         if len(field_value) < 1:
             raise ValidationError("Score sets should define at least one target gene.")
 
+        return field_value
+
     @validator("keywords")
     def validate_keywords(cls, v):
         keywords.validate_keywords(v)

--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -102,6 +102,12 @@ class ScoreSetModify(ScoreSetBase):
 
         return field_value
 
+    # Validate that this score set contains at least one target attached to it
+    @validator("target_genes")
+    def at_least_one_target_gene_exists(cls, field_value, values):
+        if len(field_value) < 1:
+            raise ValidationError("Score sets should define at least one target gene.")
+
     @validator("keywords")
     def validate_keywords(cls, v):
         keywords.validate_keywords(v)

--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -88,7 +88,7 @@ class ScoreSetModify(ScoreSetBase):
     @validator("target_genes")
     def target_labels_are_unique(cls, field_value, values):
         # Labels are only used on target sequence instances.
-        if len(field_value) > 1 and all([isinstance(target, TargetSequence) for target in field_value]):
+        if len(field_value) > 1 and all([target.target_sequence is not None for target in field_value]):
             labels = [target.target_sequence.label for target in field_value]
             dup_indices = [idx for idx, item in enumerate(labels) if item in labels[:idx]]
             if dup_indices:

--- a/tests/view_models/test_score_set.py
+++ b/tests/view_models/test_score_set.py
@@ -57,8 +57,9 @@ def test_cannot_create_score_set_with_non_unique_target_labels():
     target_gene_one = TargetGeneCreate(**jsonable_encoder(score_set_test["targetGenes"][0]))
     target_gene_two = TargetGeneCreate(**jsonable_encoder(score_set_test["targetGenes"][0]))
 
-    target_gene_one.target_sequence.label = "non_unique"
-    target_gene_two.target_sequence.label = "non_unique"
+    non_unique = "BRCA1"
+    target_gene_one.target_sequence.label = non_unique
+    target_gene_two.target_sequence.label = non_unique
 
     with pytest.raises(ValueError) as exc_info:
         ScoreSetModify(

--- a/tests/view_models/test_score_set.py
+++ b/tests/view_models/test_score_set.py
@@ -3,7 +3,8 @@ import pytest
 from fastapi.encoders import jsonable_encoder
 
 from mavedb.view_models.score_set import ScoreSetModify
-from mavedb.view_models.target_gene import TargetGene
+from mavedb.view_models.target_gene import TargetGeneCreate
+from mavedb.view_models.publication_identifier import PublicationIdentifierCreate
 
 from tests.helpers.constants import TEST_MINIMAL_SEQ_SCORESET
 
@@ -17,3 +18,51 @@ def test_cannot_create_score_set_without_a_target():
         ScoreSetModify(**jsonable_encoder(score_set_test, exclude={"targetGenes"}), target_genes=[])
 
     assert "Score sets should define at least one target gene." in str(exc_info.value)
+
+
+def test_cannot_create_score_set_with_multiple_primary_publications():
+    score_set_test = TEST_MINIMAL_SEQ_SCORESET.copy()
+
+    identifier_one = PublicationIdentifierCreate(identifier="2019.12.12.207222")
+    identifier_two = PublicationIdentifierCreate(identifier="2019.12.12.20733333")
+
+    with pytest.raises(ValueError) as exc_info:
+        ScoreSetModify(
+            **jsonable_encoder(score_set_test),
+            exclude={"targetGenes"},
+            target_genes=[TargetGeneCreate(**jsonable_encoder(target)) for target in score_set_test["targetGenes"]],
+            primary_publication_identifiers=[identifier_one, identifier_two],
+        )
+
+    assert "multiple primary publication identifiers are not allowed" in str(exc_info.value)
+
+
+def test_cannot_create_score_set_without_target_gene_labels_when_multiple_targets_exist():
+    score_set_test = TEST_MINIMAL_SEQ_SCORESET.copy()
+
+    target_gene_one = TargetGeneCreate(**jsonable_encoder(score_set_test["targetGenes"][0]))
+    target_gene_two = TargetGeneCreate(**jsonable_encoder(score_set_test["targetGenes"][0]))
+
+    with pytest.raises(ValueError) as exc_info:
+        ScoreSetModify(
+            **jsonable_encoder(score_set_test, exclude={"targetGenes"}), target_genes=[target_gene_one, target_gene_two]
+        )
+
+    assert "Target sequence labels cannot be empty when multiple targets are defined." in str(exc_info.value)
+
+
+def test_cannot_create_score_set_with_non_unique_target_labels():
+    score_set_test = TEST_MINIMAL_SEQ_SCORESET.copy()
+
+    target_gene_one = TargetGeneCreate(**jsonable_encoder(score_set_test["targetGenes"][0]))
+    target_gene_two = TargetGeneCreate(**jsonable_encoder(score_set_test["targetGenes"][0]))
+
+    target_gene_one.target_sequence.label = "non_unique"
+    target_gene_two.target_sequence.label = "non_unique"
+
+    with pytest.raises(ValueError) as exc_info:
+        ScoreSetModify(
+            **jsonable_encoder(score_set_test, exclude={"targetGenes"}), target_genes=[target_gene_one, target_gene_two]
+        )
+
+    assert "Target sequence labels cannot be duplicated." in str(exc_info.value)

--- a/tests/view_models/test_score_set.py
+++ b/tests/view_models/test_score_set.py
@@ -1,0 +1,19 @@
+import pytest
+
+from fastapi.encoders import jsonable_encoder
+
+from mavedb.view_models.score_set import ScoreSetModify
+from mavedb.view_models.target_gene import TargetGene
+
+from tests.helpers.constants import TEST_MINIMAL_SEQ_SCORESET
+
+import datetime
+
+
+def test_cannot_create_score_set_without_a_target():
+    score_set_test = TEST_MINIMAL_SEQ_SCORESET.copy()
+
+    with pytest.raises(ValueError) as exc_info:
+        ScoreSetModify(**jsonable_encoder(score_set_test, exclude={"targetGenes"}), target_genes=[])
+
+    assert "Score sets should define at least one target gene." in str(exc_info.value)

--- a/tests/view_models/test_score_set.py
+++ b/tests/view_models/test_score_set.py
@@ -17,7 +17,7 @@ def test_cannot_create_score_set_without_a_target():
     with pytest.raises(ValueError) as exc_info:
         ScoreSetModify(**jsonable_encoder(score_set_test, exclude={"targetGenes"}), target_genes=[])
 
-    assert "Score sets should define at least one target gene." in str(exc_info.value)
+    assert "Score sets should define at least one target." in str(exc_info.value)
 
 
 def test_cannot_create_score_set_with_multiple_primary_publications():


### PR DESCRIPTION
Fixes #177 

- Fixes a bug that made it possible for users to create score sets with no targets
- Fixes a bug in a score set validator that enabled users to create score sets with duplicated target sequence labels.
- Adds test coverage for the validators in the score set view model.
