### PR TITLE
Expand Target Label Allowed Characters

### DIFF
--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -89,6 +89,7 @@ class ScoreSetModify(ScoreSetBase):
     def target_labels_are_unique(cls, field_value, values):
         # Labels are only used on target sequence instances.
         if len(field_value) > 1 and all([isinstance(target, TargetSequence) for target in field_value]):
+            # Labels have already been sanitized by the TargetSequence validator.
             labels = [target.target_sequence.label for target in field_value]
             dup_indices = [idx for idx, item in enumerate(labels) if item in labels[:idx]]
             if dup_indices:

--- a/src/mavedb/view_models/target_sequence.py
+++ b/src/mavedb/view_models/target_sequence.py
@@ -9,6 +9,10 @@ from mavedb.lib.validation.exceptions import ValidationError
 from fqfa import infer_sequence_type
 
 
+def sanitize_target_sequence_label(label: str):
+    return label.strip().replace(" ", "_")
+
+
 class TargetSequenceBase(BaseModel):
     sequence_type: str
     sequence: str
@@ -44,7 +48,10 @@ class TargetSequenceModify(TargetSequenceBase):
         if isinstance(field_value, str):
             if ":" in field_value:
                 raise ValidationError(f"Target sequence label `{field_value}` may not contain a colon.")
-        return field_value
+
+        # Sanitize the label by stripping leading/trailing whitespace and replacing any internal whitespace with
+        # underscores. Fully qualified variants should never contain whitespace.
+        return sanitize_target_sequence_label(field_value)
 
 
 class TargetSequenceCreate(TargetSequenceModify):

--- a/src/mavedb/view_models/target_sequence.py
+++ b/src/mavedb/view_models/target_sequence.py
@@ -40,13 +40,10 @@ class TargetSequenceModify(TargetSequenceBase):
         return field_value
 
     @validator("label")
-    def check_alphanumeric(cls, field_value, values, field, config) -> str:
+    def label_does_not_include_colon(cls, field_value, values, field, config) -> str:
         if isinstance(field_value, str):
-            is_alphanumeric = field_value.replace("_", "").isalnum()
-            if not is_alphanumeric:
-                raise ValidationError(
-                    f"Target sequence label `{field_value}` can contain only letters, numbers, and underscores."
-                )
+            if ":" in field_value:
+                raise ValidationError(f"Target sequence label `{field_value}` may not contain a colon.")
         return field_value
 
 

--- a/tests/view_models/test_target_sequence.py
+++ b/tests/view_models/test_target_sequence.py
@@ -1,4 +1,4 @@
-from mavedb.view_models.target_sequence import TargetSequenceCreate
+from mavedb.view_models.target_sequence import TargetSequenceCreate, sanitize_target_sequence_label
 
 import pytest
 import datetime
@@ -41,6 +41,21 @@ def test_create_valid_target_sequence():
     assert target_sequence.sequence_type == sequence_type
     assert target_sequence.sequence == SEQUENCE
     assert target_sequence.label == label
+
+
+def test_target_sequence_label_is_sanitized():
+    sequence_type = "dna"
+    label = "   sanitize this label      "
+    sequence = SEQUENCE
+    taxonomy = TAXONOMY
+
+    target_sequence = TargetSequenceCreate(
+        sequence_type=sequence_type, sequence=sequence, taxonomy=taxonomy, label=label
+    )
+
+    assert target_sequence.sequence_type == sequence_type
+    assert target_sequence.sequence == SEQUENCE
+    assert target_sequence.label == sanitize_target_sequence_label(label)
 
 
 def test_cannot_create_target_sequence_with_label_containing_colon():

--- a/tests/view_models/test_target_sequence.py
+++ b/tests/view_models/test_target_sequence.py
@@ -1,0 +1,106 @@
+from mavedb.view_models.target_sequence import TargetSequenceCreate
+
+import pytest
+import datetime
+
+
+SEQUENCE = (
+    "ATGAGTATTCAACATTTCCGTGTCGCCCTTATTCCCTTTTTTGCGGCATTTTGCCTTCCTGTTTTTGCTCACCCAGAAACGCTGGTGAAAGTAAAAGATGCT"
+    "GAAGATCAGTTGGGTGCACGAGTGGGTTACATCGAACTGGATCTCAACAGCGGTAAGATCCTTGAGAGTTTTCGCCCCGAAGAACGTTTTCCAATGATGAGCACTTTTAAAGTTCT"
+    "GCTATGTGGCGCGGTATTATCCCGTGTTGACGCCGGGCAAGAGCAACTCGGTCGCCGCATACACTATTCTCAGAATGACTTGGTTGAGTACTCACCAGTCACAGAAAAGCATCTTA"
+    "CGGATGGCATGACAGTAAGAGAATTATGCAGTGCTGCCATAACCATGAGTGATAACACTGCGGCCAACTTACTTCTGACAACGATCGGAGGACCGAAGGAGCTAACCGCTTTTTTG"
+    "CACAACATGGGGGATCATGTAACTCGCCTTGATCGTTGGGAACCGGAGCTGAATGAAGCCATACCAAACGACGAGCGTGACACCACGATGCCTGCAGCAATGGCAACAACGTTGCG"
+    "CAAACTATTAACTGGCGAACTACTTACTCTAGCTTCCCGGCAACAATTAATAGACTGGATGGAGGCGGATAAAGTTGCAGGACCACTTCTGCGCTCGGCCCTTCCGGCTGGCTGGT"
+    "TTATTGCTGATAAATCTGGAGCCGGTGAGCGTGGGTCTCGCGGTATCATTGCAGCACTGGGGCCAGATGGTAAGCCCTCCCGTATCGTAGTTATCTACACGACGGGGAGTCAGGCA"
+    "ACTATGGATGAACGAAATAGACAGATCGCTGAGATAGGTGCCTCACTGATTAAGCATTGGTAA"
+)
+
+TAXONOMY = {
+    "taxId": 9606,
+    "organismName": "Homo sapiens",
+    "commonName": "human",
+    "rank": "SPECIES",
+    "hasDescribedSpeciesName": True,
+    "articleReference": "NCBI:txid9606",
+    "genomeId": None,
+    "id": 14,
+    "url": "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=info&id=9606",
+}
+
+
+def test_create_valid_target_sequence():
+    sequence_type = "dna"
+    label = "sequence_label"
+    sequence = SEQUENCE
+    taxonomy = TAXONOMY
+
+    target_sequence = TargetSequenceCreate(
+        sequence_type=sequence_type, sequence=sequence, taxonomy=taxonomy, label=label
+    )
+
+    assert target_sequence.sequence_type == sequence_type
+    assert target_sequence.sequence == SEQUENCE
+    assert target_sequence.label == label
+
+
+def test_cannot_create_target_sequence_with_label_containing_colon():
+    sequence_type = "dna"
+    label = "sequence:label"
+    sequence = SEQUENCE
+    taxonomy = TAXONOMY
+
+    with pytest.raises(ValueError) as exc_info:
+        target_sequence = TargetSequenceCreate(
+            sequence_type=sequence_type, sequence=sequence, taxonomy=taxonomy, label=label
+        )
+
+    assert f"Target sequence label `{label}` may not contain a colon." in str(exc_info.value)
+
+
+def test_cannot_create_target_sequence_with_invalid_sequence_type():
+    sequence_type = "invalid"
+    label = "sequence_label"
+    sequence = SEQUENCE
+    taxonomy = TAXONOMY
+
+    with pytest.raises(ValueError) as exc_info:
+        target_sequence = TargetSequenceCreate(
+            sequence_type=sequence_type, sequence=sequence, taxonomy=taxonomy, label=label
+        )
+
+    assert f"'{sequence_type}' is not a valid sequence type" in str(exc_info.value)
+
+
+def test_cannot_create_target_sequence_with_invalid_inferred_type():
+    sequence_type = "infer"
+    label = "sequence_label"
+    sequence = SEQUENCE + "!"
+    taxonomy = TAXONOMY
+
+    with pytest.raises(ValueError) as exc_info:
+        target_sequence = TargetSequenceCreate(
+            sequence_type=sequence_type, sequence=sequence, taxonomy=taxonomy, label=label
+        )
+
+    assert "sequence is invalid" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "sequence_type,exc_string",
+    (
+        ("dna", "invalid dna sequence provided"),
+        ("protein", "invalid protein sequence provided"),
+        ("invalid", "'invalid' is not a valid sequence type"),
+    ),
+)
+def test_cannot_create_target_sequence_with_invalid_sequence(sequence_type, exc_string):
+    label = "sequence_label"
+    sequence = SEQUENCE + "!"
+    taxonomy = TAXONOMY
+
+    with pytest.raises(ValueError) as exc_info:
+        target_sequence = TargetSequenceCreate(
+            sequence_type=sequence_type, sequence=sequence, taxonomy=taxonomy, label=label
+        )
+
+    assert exc_string in str(exc_info.value)


### PR DESCRIPTION
Fixes #190 

When using target labels on sequences to validate score and count data, we split variants on the same line by spaces and we split the fully qualified variant on ':' to infer the label and hgvs string. See: https://github.com/VariantEffect/mavedb-api/blob/fa1ce7d0bfd57f0e178719f462273b764a467212/src/mavedb/lib/validation/dataframe.py#L421-L424

Spaces and colons are the only characters that need to be reserved from our perspective. We can raise a validation error if a user tries to include a colon in their target label and sanitize the label of any whitespace during validation.

Adds view model tests for target sequences.