### PR TITLE
Revert ENV-ifying of ORCID public key and app ID.

### DIFF
--- a/src/mavedb/lib/authentication.py
+++ b/src/mavedb/lib/authentication.py
@@ -16,8 +16,17 @@ from mavedb.lib.orcid import fetch_orcid_user_email
 from mavedb.models.access_key import AccessKey
 from mavedb.models.user import User
 
-ORCID_JWT_SIGNING_PUBLIC_KEY = os.getenv("ORCID_JWT_SIGNING_PUBLIC_KEY", "")
-ORCID_JWT_AUDIENCE = os.getenv("ORCID_CLIENT_ID")
+ORCID_JWT_SIGNING_PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjxTIntA7YvdfnYkLSN4w
+k//E2zf/wbb0SV/HLHFvh6a9ENVRD1/rHK0EijlBzikb+1rgDQihJETcgBLsMoZV
+QqGj8fDUUuxnVHsuGav/bf41PA7E/58HXKPrB2C0cON41f7K3o9TStKpVJOSXBrR
+WURmNQ64qnSSryn1nCxMzXpaw7VUo409ohybbvN6ngxVy4QR2NCC7Fr0QVdtapxD
+7zdlwx6lEwGemuqs/oG5oDtrRuRgeOHmRps2R6gG5oc+JqVMrVRv6F9h4ja3UgxC
+DBQjOVT1BFPWmMHnHCsVYLqbbXkZUfvP2sO1dJiYd/zrQhi+FtNth9qrLLv3gkgt
+wQIDAQAB
+-----END PUBLIC KEY-----
+"""
+ORCID_JWT_AUDIENCE = "APP-GXFVWWJT8H0F50WD"
 
 ACCESS_TOKEN_NAME = "X-API-key"
 


### PR DESCRIPTION
Our current mechanism for setting env vars on AWS doesn't allow for non-printable characters, which the public key contains. Rather than base64-encoding and then decoding it or similar, we've decided that, as we have no use at present for varying these values and neither is secret, to revert to declaring them explicitly in the code.