### PR TITLE
fix: DOI Based Publications Return 404 on GET (#220)

### DIFF
--- a/src/mavedb/routers/publication_identifiers.py
+++ b/src/mavedb/routers/publication_identifiers.py
@@ -14,7 +14,8 @@ from mavedb.models.publication_identifier import PublicationIdentifier
 from mavedb.view_models import publication_identifier
 from mavedb.view_models.search import TextSearch
 
-PublicationDataBases = Enum("PublicationDataBases", ((x, x) for x in valid_dbnames))
+# I don't think we can escape the type: ignore hint here on a dynamically created enumerated type.
+PublicationDatabases = Enum("PublicationDataBases", ((x, x) for x in valid_dbnames))  # type: ignore
 
 
 router = APIRouter(
@@ -87,7 +88,7 @@ def fetch_publication_by_identifier(*, identifier: str, db: Session = Depends(de
 )
 def fetch_publication_by_dbname_and_identifier(
     *,
-    db_name: PublicationDataBases,
+    db_name: PublicationDatabases,
     identifier: str,
     db: Session = Depends(deps.get_db),
 ) -> PublicationIdentifier:

--- a/src/mavedb/routers/publication_identifiers.py
+++ b/src/mavedb/routers/publication_identifiers.py
@@ -1,15 +1,21 @@
+from enum import Enum
 from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, or_
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Session
+from starlette.convertors import Convertor, register_url_convertor
 
 from mavedb import deps
-from mavedb.lib.identifiers import find_generic_article, find_or_create_publication_identifier
+from mavedb.lib.identifiers import find_generic_article
+from mavedb.lib.validation.constants.publication import valid_dbnames
 from mavedb.models.publication_identifier import PublicationIdentifier
 from mavedb.view_models import publication_identifier
 from mavedb.view_models.search import TextSearch
+
+PublicationDataBases = Enum("PublicationDataBases", ((x, x) for x in valid_dbnames))
+
 
 router = APIRouter(
     prefix="/api/v1/publication-identifiers",
@@ -27,8 +33,31 @@ def list_publications(*, db: Session = Depends(deps.get_db)) -> Any:
     return items
 
 
+# See https://github.com/tiangolo/fastapi/discussions/7328, which describes that slashes are currently un-escapable in FastAPI/Starlette
+# implementations.
+#
+# Workaround here by defining a custom type convertor (see https://www.starlette.io/routing/#path-parameters) whose
+# RegEx match matches our accepted publication identifiers. When the API is queried and the string matches the convertor, we enter the
+# route on which the convertor captured a match, use the match as our variable of interest, and resolve the route. By capturing the match,
+# we retain the ability to add routes such as /db_name/identifier or /identifier/title since we can now match to these unescapable slashes
+# without matching the rest of the path as a path type, as the `:path` convertor would have. In the OpenAPI spec, this type will still be
+# represented as a 'path'. -capodb 2024.05.30
+class PublicationIdentifierConverter(Convertor):
+    # RegEx structure: "DOI | PubMed | bioRxiv | medRxiv"
+    regex = "10[.][0-9]{4,9}\/[-._;()\/:A-z0-9]+|[0-9]{0,8}|[0-9]{4}[.][0-9]{2}[.][0-9]{2}[.][0-9]{6}|[0-9]{4}[.][0-9]{2}[.][0-9]{2}[.][0-9]{8}"
+
+    def convert(self, value: str) -> str:
+        return value
+
+    def to_string(self, value: str) -> str:
+        return str(value)
+
+
+register_url_convertor("publication", PublicationIdentifierConverter())
+
+
 @router.get(
-    "/{identifier}",
+    "/{identifier:publication}",
     status_code=200,
     response_model=publication_identifier.PublicationIdentifier,
     responses={404: {}},
@@ -51,14 +80,14 @@ def fetch_publication_by_identifier(*, identifier: str, db: Session = Depends(de
 
 
 @router.get(
-    "/{db_name}/{identifier}",
+    "/{db_name:str}/{identifier:publication}",
     status_code=200,
     response_model=publication_identifier.PublicationIdentifier,
     responses={404: {}},
 )
 def fetch_publication_by_dbname_and_identifier(
     *,
-    db_name: str,
+    db_name: PublicationDataBases,
     identifier: str,
     db: Session = Depends(deps.get_db),
 ) -> PublicationIdentifier:
@@ -68,18 +97,19 @@ def fetch_publication_by_dbname_and_identifier(
     try:
         item = (
             db.query(PublicationIdentifier)
-            .filter(PublicationIdentifier.identifier == identifier and PublicationIdentifier.db_name == db_name)
+            .filter(PublicationIdentifier.identifier == identifier)
+            .filter(PublicationIdentifier.db_name == db_name.name)
             .one_or_none()
         )
     except MultipleResultsFound:
         raise HTTPException(
             status_code=500,
-            detail=f"Multiple publications with identifier {identifier} and database name {db_name} were found.",
+            detail=f"Multiple publications with identifier {identifier} and database name {db_name.name} were found.",
         )
     if not item:
         raise HTTPException(
             status_code=404,
-            detail=f"No publication with identifier {identifier} and database name {db_name} were found.",
+            detail=f"No publication with identifier {identifier} and database name {db_name.name} were found.",
         )
     return item
 


### PR DESCRIPTION
Works around a starlette/fastapi 'feature' where URL encoded slashes are treated like hierarchical paths. Adds a type convertor for publication identifiers which matches identifiers via RegEx for identifiers which we support. This allows us to parse out DOIs (with their slashes) before FastAPI wrongly attempts to use them as a hierarchical path.

fixes #220 