### PR TITLE
Support Searching for Publications via URL

### DIFF
--- a/src/mavedb/lib/identifiers.py
+++ b/src/mavedb/lib/identifiers.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from mavedb.lib.exceptions import AmbiguousIdentifierError, NonexistentIdentifierError
 from mavedb.lib.external_publications import Rxiv, Crossref, CrossrefWork, RxivContentDetail, PublicationAuthors
-from mavedb.lib.validation.publication import identifier_valid_for, validate_db_name
+from mavedb.lib.validation.publication import identifier_valid_for, validate_db_name, infer_identifier_from_url
 from mavedb.models.doi_identifier import DoiIdentifier
 from mavedb.models.ensembl_identifier import EnsemblIdentifier
 from mavedb.models.ensembl_offset import EnsemblOffset
@@ -259,6 +259,9 @@ async def find_generic_article(
         "bioRxiv": fetch_biorxiv_article,
         "medRxiv": fetch_medrxiv_article,
     }
+
+    # We also accept URLs from our accepted publications. Attempt to convert a potential URL to an identifier.
+    identifier = infer_identifier_from_url(identifier)
 
     # Only check entries with the appropriate `db_name` if one is provided.
     db_specific_match: dict[str, Union[PublicationIdentifier, ExternalPublication, None]] = {}

--- a/tests/validation/test_publication.py
+++ b/tests/validation/test_publication.py
@@ -7,6 +7,7 @@ from mavedb.lib.validation.publication import (
     validate_medrxiv,
     identifier_valid_for,
     validate_db_name,
+    infer_identifier_from_url,
 )
 from mavedb.lib.validation.exceptions import ValidationError
 from mavedb.lib.validation.constants.publication import valid_dbnames
@@ -21,6 +22,9 @@ class TestValidateGenericPublication(TestCase):
 
     def test_valid_medrxiv(self):
         assert validate_publication("20733333") == None
+
+    def test_valid_crossref(self):
+        assert validate_publication("10.1101/1234") == None
 
     def test_invalid_identifier(self):
         with self.assertRaises(ValidationError):
@@ -74,6 +78,7 @@ class TestIdentifierValidFor(TestCase):
             "PubMed": True,
             "bioRxiv": False,
             "medRxiv": False,
+            "Crossref": False,
         }
 
     def test_valid_biorxiv(self):
@@ -81,6 +86,7 @@ class TestIdentifierValidFor(TestCase):
             "PubMed": False,
             "bioRxiv": True,
             "medRxiv": False,
+            "Crossref": False,
         }
 
     def test_valid_medrxiv(self):
@@ -88,6 +94,7 @@ class TestIdentifierValidFor(TestCase):
             "PubMed": False,
             "bioRxiv": False,
             "medRxiv": True,
+            "Crossref": False,
         }
 
     def test_valid_pubmed_biorxiv(self):
@@ -95,6 +102,7 @@ class TestIdentifierValidFor(TestCase):
             "PubMed": True,
             "bioRxiv": True,
             "medRxiv": False,
+            "Crossref": False,
         }
 
     def test_valid_pubmed_medrxiv(self):
@@ -102,6 +110,7 @@ class TestIdentifierValidFor(TestCase):
             "PubMed": True,
             "bioRxiv": False,
             "medRxiv": True,
+            "Crossref": False,
         }
 
     def test_valid_pubmed_none(self):
@@ -109,6 +118,15 @@ class TestIdentifierValidFor(TestCase):
             "PubMed": False,
             "bioRxiv": False,
             "medRxiv": False,
+            "Crossref": False,
+        }
+
+    def test_valid_crossref(self):
+        assert identifier_valid_for("10.1101/1234") == {
+            "PubMed": False,
+            "bioRxiv": False,
+            "medRxiv": False,
+            "Crossref": True,
         }
 
 
@@ -124,3 +142,30 @@ class TestValidateDbName(TestCase):
     def test_invalid_name(self):
         with self.assertRaises(ValidationError):
             validate_db_name("invalid db")
+
+
+class TestInferIdentifierFromUrl(TestCase):
+    def test_doi_url(self):
+        assert infer_identifier_from_url("http://www.dx.doi.org/10.1101/1234") == "10.1101/1234"
+
+    def test_biorxiv_url(self):
+        assert (
+            infer_identifier_from_url("https://www.biorxiv.org/content/10.1101/2024.04.26.591310")
+            == "2024.04.26.591310"
+        )
+
+    def test_medrxiv_url(self):
+        assert (
+            infer_identifier_from_url("https://www.medrxiv.org/content/10.1101/2024.04.26.59131023")
+            == "2024.04.26.59131023"
+        )
+
+    def test_pubmed_url(self):
+        assert infer_identifier_from_url("https://pubmed.ncbi.nlm.nih.gov/24567513/") == "24567513"
+        assert infer_identifier_from_url("http://www.ncbi.nlm.nih.gov/pubmed/432") == "432"
+
+    def test_identifier_not_url(self):
+        assert infer_identifier_from_url("29023") == "29023"
+
+    def test_url_not_accepted(self):
+        assert infer_identifier_from_url("www.notaccepted.org/29023") == "www.notaccepted.org/29023"


### PR DESCRIPTION
Adds support to search for publications via URLs from accepted publication databases. If a user submits a publication identifier that appears to be a URL, the publication database is inferred via the URL string and an identifier is parsed from the URL based on the known format of that publication databases URL.

Closes #227 