### PR TITLE
Fixed: Executing Jobs Were Sharing DB Sessions

### DIFF
--- a/src/mavedb/worker/settings.py
+++ b/src/mavedb/worker/settings.py
@@ -21,14 +21,23 @@ RedisWorkerSettings = RedisSettings(host=REDIS_IP, port=REDIS_PORT, ssl=REDIS_SS
 
 
 async def startup(ctx):
+    pass
+
+
+async def shutdown(ctx):
+    pass
+
+
+async def on_job_start(ctx):
     db = SessionLocal()
     db.current_user_id = None
     ctx["db"] = db
     ctx["hdp"] = cdot_rest()
 
 
-async def shutdown(ctx):
-    pass
+async def on_job_end(ctx):
+    db = ctx["db"]
+    db.close()
 
 
 class ArqWorkerSettings:
@@ -38,6 +47,8 @@ class ArqWorkerSettings:
 
     on_startup = startup
     on_shutdown = shutdown
+    on_job_start = on_job_start
+    on_job_end = on_job_end
     redis_settings = RedisWorkerSettings
     functions: list = BACKGROUND_FUNCTIONS
     cron_jobs: list = BACKGROUND_CRONJOBS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,11 +145,19 @@ async def arq_worker(data_provider, session, arq_redis):
     """
 
     async def on_startup(ctx):
+        pass
+
+    async def on_job(ctx):
         ctx["db"] = session
         ctx["hdp"] = data_provider
 
     worker_ = Worker(
-        functions=[create_variants_for_score_set], redis_pool=arq_redis, burst=True, poll_delay=0, on_startup=on_startup
+        functions=[create_variants_for_score_set],
+        redis_pool=arq_redis,
+        burst=True,
+        poll_delay=0,
+        on_startup=on_startup,
+        on_job_start=on_job,
     )
     # `fakeredis` does not support `INFO`
     with patch("arq.worker.log_redis_info"):


### PR DESCRIPTION
Fixes #260.

Since the SQLAlchemy Session object was defined on worker startup, jobs running at the same time were sharing a worker session. This could cause unexpected commits and/or rollbacks, in addition to blocking work in the event that a job left the session in an unrecoverable state. This change creates a session at the start of each job, defining it on the job's context rather than the worker's context. This will ensure interactions between jobs and the database are fully independent.