### PR TITLE
Debug statistics record score-set and keywords problem.

### DIFF
--- a/src/mavedb/routers/statistics.py
+++ b/src/mavedb/routers/statistics.py
@@ -260,7 +260,6 @@ def _record_from_field_and_model(
     model_created_by_field = getattr(queried_model, "created_by_id")
     model_published_data_field = getattr(queried_model, "published_date")
     if field is RecordFields.createdBy:
-        print("111")
         query = (
             select(User.username, func.count(User.id))
             .join(queried_model, model_created_by_field == User.id)
@@ -270,7 +269,6 @@ def _record_from_field_and_model(
 
         return db.execute(query).all()
     else:
-        print("2222")
         # All assc table identifiers which are linked to a published model.
         queried_assc_table = association_tables[model][field]
         published_score_sets_statement = (

--- a/src/mavedb/routers/statistics.py
+++ b/src/mavedb/routers/statistics.py
@@ -260,6 +260,7 @@ def _record_from_field_and_model(
     model_created_by_field = getattr(queried_model, "created_by_id")
     model_published_data_field = getattr(queried_model, "published_date")
     if field is RecordFields.createdBy:
+        print("111")
         query = (
             select(User.username, func.count(User.id))
             .join(queried_model, model_created_by_field == User.id)
@@ -269,6 +270,7 @@ def _record_from_field_and_model(
 
         return db.execute(query).all()
     else:
+        print("2222")
         # All assc table identifiers which are linked to a published model.
         queried_assc_table = association_tables[model][field]
         published_score_sets_statement = (
@@ -332,6 +334,11 @@ def record_object_statistics(
     Model names and fields should be members of the Enum classes defined above. Providing an invalid model name or
     model field will yield a 422 Unprocessable Entity error with details about valid enum values.
     """
+    # Validation to ensure 'keywords' is only used with 'experiment'.
+    if model == RecordNames.scoreSet and field == RecordFields.keywords:
+        raise HTTPException(status_code=422,
+                            detail="The 'keywords' field can only be used with the 'experiment' model.")
+
     count_data = _record_from_field_and_model(db, model, field)
 
     return {field_val: count for field_val, count in count_data if field_val is not None}


### PR DESCRIPTION
Model options are from Class RecordNames(experiment and score-set) and fields options are from Class RecordFields(publication-identifiers, keywords, doi-identifiers, raw-read-identifiers and created-by). 

However, score-set doesn't have keywords anymore. Hence, adding a validator to handle this case. 