### PR TITLE
User-specific target gene search

### DIFF
--- a/src/mavedb/lib/target_genes.py
+++ b/src/mavedb/lib/target_genes.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Optional
+
+from sqlalchemy import func, or_
+from sqlalchemy.orm import Session, aliased, contains_eager, joinedload, selectinload
+
+from mavedb.lib.logging.context import logging_context, save_to_logging_context
+from mavedb.models.contributor import Contributor
+from mavedb.models.score_set import ScoreSet
+from mavedb.models.target_gene import TargetGene
+from mavedb.models.user import User
+from mavedb.view_models.search import TextSearch
+
+VariantData = dict[str, Optional[dict[str, dict]]]
+
+logger = logging.getLogger(__name__)
+
+
+def search_target_genes(db: Session, owner_or_contributor: Optional[User], search: TextSearch, limit: Optional[int]) -> list[TargetGene]:
+    save_to_logging_context({"target_gene_search_criteria": search.dict()})
+
+    query = db.query(TargetGene)
+
+    if search.text and len(search.text.strip()) > 0:
+        lower_search_text = search.text.strip().lower()
+        query = query.filter(func.lower(TargetGene.name).contains(lower_search_text))
+    if owner_or_contributor is not None:
+        query = query.filter(
+            TargetGene.score_set.has(
+                or_(
+                    ScoreSet.created_by_id == owner_or_contributor.id,
+                    ScoreSet.contributors.any(Contributor.orcid_id == owner_or_contributor.username),
+                )
+            )
+        )
+
+    query = query.order_by(TargetGene.name)
+    if limit is not None:
+        query = query.limit(limit)
+
+    target_genes = query.all()
+    if not target_genes:
+        target_genes = []
+
+    save_to_logging_context({"matching_resources": len(target_genes)})
+    logger.debug(msg=f"Target gene search yielded {len(target_genes)} matching resources.", extra=logging_context())
+
+    return target_genes

--- a/src/mavedb/lib/target_genes.py
+++ b/src/mavedb/lib/target_genes.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 from sqlalchemy import func, or_
-from sqlalchemy.orm import Session, aliased, contains_eager, joinedload, selectinload
+from sqlalchemy.orm import Session
 
 from mavedb.lib.logging.context import logging_context, save_to_logging_context
 from mavedb.models.contributor import Contributor
@@ -16,7 +16,12 @@ VariantData = dict[str, Optional[dict[str, dict]]]
 logger = logging.getLogger(__name__)
 
 
-def search_target_genes(db: Session, owner_or_contributor: Optional[User], search: TextSearch, limit: Optional[int]) -> list[TargetGene]:
+def search_target_genes(
+    db: Session,
+    owner_or_contributor: Optional[User],
+    search: TextSearch,
+    limit: Optional[int],
+) -> list[TargetGene]:
     save_to_logging_context({"target_gene_search_criteria": search.dict()})
 
     query = db.query(TargetGene)
@@ -29,7 +34,9 @@ def search_target_genes(db: Session, owner_or_contributor: Optional[User], searc
             TargetGene.score_set.has(
                 or_(
                     ScoreSet.created_by_id == owner_or_contributor.id,
-                    ScoreSet.contributors.any(Contributor.orcid_id == owner_or_contributor.username),
+                    ScoreSet.contributors.any(
+                        Contributor.orcid_id == owner_or_contributor.username
+                    ),
                 )
             )
         )
@@ -43,6 +50,9 @@ def search_target_genes(db: Session, owner_or_contributor: Optional[User], searc
         target_genes = []
 
     save_to_logging_context({"matching_resources": len(target_genes)})
-    logger.debug(msg=f"Target gene search yielded {len(target_genes)} matching resources.", extra=logging_context())
+    logger.debug(
+        msg=f"Target gene search yielded {len(target_genes)} matching resources.",
+        extra=logging_context(),
+    )
 
     return target_genes

--- a/src/mavedb/lib/target_genes.py
+++ b/src/mavedb/lib/target_genes.py
@@ -11,8 +11,6 @@ from mavedb.models.target_gene import TargetGene
 from mavedb.models.user import User
 from mavedb.view_models.search import TextSearch
 
-VariantData = dict[str, Optional[dict[str, dict]]]
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/mavedb/routers/target_genes.py
+++ b/src/mavedb/routers/target_genes.py
@@ -1,18 +1,35 @@
 from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from mavedb import deps
+from mavedb.lib.authentication import UserData
+from mavedb.lib.authorization import require_current_user
+from mavedb.lib.target_genes import (
+    search_target_genes as _search_target_genes,
+)
 from mavedb.models.target_gene import TargetGene
 from mavedb.view_models import target_gene
 from mavedb.view_models.search import TextSearch
 
-router = APIRouter(prefix="/api/v1/target-genes", tags=["target-genes"], responses={404: {"description": "Not found"}})
+router = APIRouter(prefix="/api/v1", tags=["target-genes"], responses={404: {"description": "Not found"}})
 
 
-@router.get("/", status_code=200, response_model=List[target_gene.TargetGene], responses={404: {}})
+@router.post("/me/target-genes/search", status_code=200, response_model=List[target_gene.TargetGene])
+def search_target_genes(
+    search: TextSearch,
+    db: Session = Depends(deps.get_db),
+    user_data: UserData = Depends(require_current_user)
+) -> Any:
+    """
+    Search my target genes.
+    """
+
+    return _search_target_genes(db, user_data.user, search, 50)
+
+
+@router.get("/target-genes", status_code=200, response_model=List[target_gene.TargetGene], responses={404: {}})
 def list_target_genes(
     *,
     db: Session = Depends(deps.get_db),
@@ -24,7 +41,7 @@ def list_target_genes(
     return items
 
 
-@router.get("/names", status_code=200, response_model=List[str], responses={404: {}})
+@router.get("/target-genes/names", status_code=200, response_model=List[str], responses={404: {}})
 def list_target_gene_names(
     *,
     db: Session = Depends(deps.get_db),
@@ -38,7 +55,7 @@ def list_target_gene_names(
     return sorted(list(set(names)))
 
 
-@router.get("/categories", status_code=200, response_model=List[str], responses={404: {}})
+@router.get("/target-genes/categories", status_code=200, response_model=List[str], responses={404: {}})
 def list_target_gene_categories(
     *,
     db: Session = Depends(deps.get_db),
@@ -52,7 +69,7 @@ def list_target_gene_categories(
     return sorted(list(set(categories)))
 
 
-@router.get("/{item_id}", status_code=200, response_model=target_gene.TargetGene, responses={404: {}})
+@router.get("/target-genes/{item_id}", status_code=200, response_model=target_gene.TargetGene, responses={404: {}})
 def fetch_target_gene(
     *,
     item_id: int,
@@ -67,20 +84,13 @@ def fetch_target_gene(
     return item
 
 
-@router.post("/search", status_code=200, response_model=List[target_gene.TargetGene])
-def search_target_genes(search: TextSearch, db: Session = Depends(deps.get_db)) -> Any:
+@router.post("/target-genes/search", status_code=200, response_model=List[target_gene.TargetGene])
+def search_target_genes(
+    search: TextSearch,
+    db: Session = Depends(deps.get_db)
+) -> Any:
     """
     Search target genes.
     """
 
-    query = db.query(TargetGene)
-
-    if search.text and len(search.text.strip()) > 0:
-        lower_search_text = search.text.strip().lower()
-        query = query.filter(func.lower(TargetGene.name).contains(lower_search_text))
-    else:
-        raise HTTPException(status_code=500, detail="Search text is required")
-    items = query.order_by(TargetGene.name).limit(50).all()
-    if not items:
-        items = []
-    return items
+    return _search_target_genes(db, None, search, 50)

--- a/src/mavedb/routers/target_genes.py
+++ b/src/mavedb/routers/target_genes.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/api/v1", tags=["target-genes"], responses={404: {"de
 
 
 @router.post("/me/target-genes/search", status_code=200, response_model=List[target_gene.TargetGene])
-def search_target_genes(
+def search_my_target_genes(
     search: TextSearch,
     db: Session = Depends(deps.get_db),
     user_data: UserData = Depends(require_current_user)

--- a/tests/routers/test_target_gene.py
+++ b/tests/routers/test_target_gene.py
@@ -1,0 +1,59 @@
+from mavedb.models.score_set import ScoreSet as ScoreSetDbModel
+from tests.helpers.util import (
+    change_ownership,
+    create_experiment,
+    create_seq_score_set_with_variants,
+)
+
+
+def test_search_my_target_genes_no_match(session, data_provider, client, setup_router_db, data_files):
+    experiment_1 = create_experiment(client, {"title": "Experiment 1"})
+    create_seq_score_set_with_variants(
+        client,
+        session,
+        data_provider,
+        experiment_1["urn"],
+        data_files / "scores.csv",
+        update={"title": "Test Score Set"},
+    )
+
+    search_payload = {"text": "NONEXISTENT"}
+    response = client.post("/api/v1/target-genes/search", json=search_payload)
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_search_my_target_genes_no_match_on_other_user(session, data_provider, client, setup_router_db, data_files):
+    experiment_1 = create_experiment(client, {"title": "Experiment 1"})
+    score_set = create_seq_score_set_with_variants(
+        client,
+        session,
+        data_provider,
+        experiment_1["urn"],
+        data_files / "scores.csv",
+        update={"title": "Test Score Set"},
+    )
+    change_ownership(session, score_set["urn"], ScoreSetDbModel)
+
+    search_payload = {"text": "TEST1"}
+    response = client.post("/api/v1/target-genes/search", json=search_payload)
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_search_my_target_genes_match(session, data_provider, client, setup_router_db, data_files):
+    experiment_1 = create_experiment(client, {"title": "Experiment 1"})
+    create_seq_score_set_with_variants(
+        client,
+        session,
+        data_provider,
+        experiment_1["urn"],
+        data_files / "scores.csv",
+        update={"title": "Test Score Set"},
+    )
+
+    search_payload = {"text": "TEST1"}
+    response = client.post("/api/v1/target-genes/search", json=search_payload)
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["name"] == "TEST1"

--- a/tests/routers/test_target_gene.py
+++ b/tests/routers/test_target_gene.py
@@ -18,7 +18,7 @@ def test_search_my_target_genes_no_match(session, data_provider, client, setup_r
     )
 
     search_payload = {"text": "NONEXISTENT"}
-    response = client.post("/api/v1/target-genes/search", json=search_payload)
+    response = client.post("/api/v1/me/target-genes/search", json=search_payload)
     assert response.status_code == 200
     assert len(response.json()) == 0
 
@@ -36,12 +36,66 @@ def test_search_my_target_genes_no_match_on_other_user(session, data_provider, c
     change_ownership(session, score_set["urn"], ScoreSetDbModel)
 
     search_payload = {"text": "TEST1"}
-    response = client.post("/api/v1/target-genes/search", json=search_payload)
+    response = client.post("/api/v1/me/target-genes/search", json=search_payload)
     assert response.status_code == 200
     assert len(response.json()) == 0
 
 
 def test_search_my_target_genes_match(session, data_provider, client, setup_router_db, data_files):
+    experiment_1 = create_experiment(client, {"title": "Experiment 1"})
+    create_seq_score_set_with_variants(
+        client,
+        session,
+        data_provider,
+        experiment_1["urn"],
+        data_files / "scores.csv",
+        update={"title": "Test Score Set"},
+    )
+
+    search_payload = {"text": "TEST1"}
+    response = client.post("/api/v1/me/target-genes/search", json=search_payload)
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["name"] == "TEST1"
+
+
+def test_search_target_genes_no_match(session, data_provider, client, setup_router_db, data_files):
+    experiment_1 = create_experiment(client, {"title": "Experiment 1"})
+    create_seq_score_set_with_variants(
+        client,
+        session,
+        data_provider,
+        experiment_1["urn"],
+        data_files / "scores.csv",
+        update={"title": "Test Score Set"},
+    )
+
+    search_payload = {"text": "NONEXISTENT"}
+    response = client.post("/api/v1/target-genes/search", json=search_payload)
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_search_target_genes_match_on_other_user(session, data_provider, client, setup_router_db, data_files):
+    experiment_1 = create_experiment(client, {"title": "Experiment 1"})
+    score_set = create_seq_score_set_with_variants(
+        client,
+        session,
+        data_provider,
+        experiment_1["urn"],
+        data_files / "scores.csv",
+        update={"title": "Test Score Set"},
+    )
+    change_ownership(session, score_set["urn"], ScoreSetDbModel)
+
+    search_payload = {"text": "TEST1"}
+    response = client.post("/api/v1/target-genes/search", json=search_payload)
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["name"] == "TEST1"
+
+
+def test_search_target_genes_match(session, data_provider, client, setup_router_db, data_files):
     experiment_1 = create_experiment(client, {"title": "Experiment 1"})
     create_seq_score_set_with_variants(
         client,


### PR DESCRIPTION
**Notes**
- I’ve retained the general target gene search, although we don’t currently have a use case for it.
- I added simple test cases for user-specific target gene search. We could probably add more target-gene-related cases, but these cover the changes made here.
- I decided to place the user-specific target gene search in a new endpoint, /me/target-genes/search, on the model of /me/score-sets/search. An alternative would be to include a "limit to current user" parameter in the search request itself. Since we don't need users to be able to search each others' data, I thought presenting this as a separate REST collection made sense. But I'm open to changing it if someone thinks otherwise.