### PR TITLE
Feature/bencap/239/record type field

### DIFF
--- a/src/mavedb/view_models/__init__.py
+++ b/src/mavedb/view_models/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from pydantic import validator
 from pydantic.utils import GetterDict
 
 
@@ -24,3 +25,12 @@ class PublicationIdentifiersGetter(GetterDict):
             return [assc.publication for assc in pub_assc if assc.primary]
         else:
             return super().get(key, default)
+
+
+def record_type_validator():
+    return validator("record_type", allow_reuse=True, pre=True, always=True)
+
+
+def set_record_type(cls, v):
+    # Record type will be set to the class name no matter the input.
+    return cls.__name__

--- a/src/mavedb/view_models/access_key.py
+++ b/src/mavedb/view_models/access_key.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import Optional
 
 from mavedb.models.enums.user_role import UserRole
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel
 
 
@@ -14,10 +15,13 @@ class AccessKeyBase(BaseModel):
 
 # Properties shared by models stored in DB
 class SavedAccessKey(AccessKeyBase):
+    record_type: str = None  # type: ignore
+    role: Optional[UserRole]
+
+    _record_type_factory = record_type_validator()(set_record_type)
+
     class Config:
         orm_mode = True
-
-    role: Optional[UserRole]
 
 
 # Properties to return to non-admin clients

--- a/src/mavedb/view_models/contributor.py
+++ b/src/mavedb/view_models/contributor.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel
 
 
@@ -18,8 +19,11 @@ class ContributorCreate(ContributorBase):
 class SavedContributor(ContributorBase):
     """Base class for contributor view models representing saved records."""
 
+    record_type: str = None  # type: ignore
     given_name: Optional[str]
     family_name: Optional[str]
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/doi_identifier.py
+++ b/src/mavedb/view_models/doi_identifier.py
@@ -1,6 +1,7 @@
 import idutils
 
 from mavedb.lib.validation.exceptions import ValidationError
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 
 
@@ -19,7 +20,10 @@ class DoiIdentifierCreate(DoiIdentifierBase):
 # Properties shared by models stored in DB
 class SavedDoiIdentifier(DoiIdentifierBase):
     id: int
+    record_type: str = None  # type: ignore
     url: str
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/experiment.py
+++ b/src/mavedb/view_models/experiment.py
@@ -3,7 +3,7 @@ from typing import Any, Collection, Optional, Sequence
 
 from mavedb.lib.validation.exceptions import ValidationError
 from mavedb.lib.validation.utilities import is_null
-from mavedb.view_models import PublicationIdentifiersGetter
+from mavedb.view_models import PublicationIdentifiersGetter, record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 from mavedb.view_models.contributor import Contributor, ContributorCreate
 from mavedb.view_models.doi_identifier import (
@@ -91,6 +91,7 @@ class ExperimentUpdate(ExperimentModify):
 
 # Properties shared by models stored in DB
 class SavedExperiment(ExperimentBase):
+    record_type: str = None  # type: ignore
     urn: str
     created_by: SavedUser
     modified_by: SavedUser
@@ -104,6 +105,8 @@ class SavedExperiment(ExperimentBase):
     raw_read_identifiers: Sequence[SavedRawReadIdentifier]
     contributors: list[Contributor]
     keywords: Sequence[SavedExperimentControlledKeyword]
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/experiment_controlled_keyword.py
+++ b/src/mavedb/view_models/experiment_controlled_keyword.py
@@ -3,7 +3,7 @@ from typing import Optional
 from pydantic import root_validator
 
 from mavedb.lib.validation import keywords
-from mavedb.view_models import keyword
+from mavedb.view_models import keyword, record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel
 
 
@@ -39,6 +39,10 @@ class ExperimentControlledKeywordUpdate(ExperimentControlledKeywordBase):
 
 class SavedExperimentControlledKeyword(ExperimentControlledKeywordBase):
     """Base class for keyword view models representing saved records."""
+
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/experiment_set.py
+++ b/src/mavedb/view_models/experiment_set.py
@@ -3,6 +3,7 @@ from typing import Sequence
 
 from pydantic.types import Optional
 
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel
 from mavedb.view_models.contributor import Contributor
 from mavedb.view_models.experiment import Experiment, ExperimentPublicDump, SavedExperiment
@@ -25,12 +26,15 @@ class ExperimentSetUpdate(ExperimentSetBase):
 # Properties shared by models stored in DB
 class SavedExperimentSet(ExperimentSetBase):
     id: int
+    record_type: str = None  # type: ignore
     experiments: Sequence[SavedExperiment]
     created_by: Optional[SavedUser]
     modified_by: Optional[SavedUser]
     creation_date: date
     modification_date: date
     contributors: list[Contributor]
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/external_gene_identifier.py
+++ b/src/mavedb/view_models/external_gene_identifier.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from mavedb.lib.validation import identifier as identifier_validator
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 
 
@@ -27,9 +28,12 @@ class ExternalGeneIdentifierCreate(ExternalGeneIdentifierBase):
 
 # Properties shared by models stored in DB
 class SavedExternalGeneIdentifier(ExternalGeneIdentifierBase):
+    record_type: str = None  # type: ignore
     db_version: Optional[str]
     url: Optional[str]
     reference_html: Optional[str]
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/external_gene_identifier_offset.py
+++ b/src/mavedb/view_models/external_gene_identifier_offset.py
@@ -1,4 +1,4 @@
-from mavedb.view_models import external_gene_identifier
+from mavedb.view_models import external_gene_identifier, record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 
 
@@ -19,7 +19,10 @@ class ExternalGeneIdentifierOffsetCreate(ExternalGeneIdentifierOffsetBase):
 
 # Properties shared by models stored in DB
 class SavedExternalGeneIdentifierOffset(ExternalGeneIdentifierOffsetBase):
+    record_type: str = None  # type: ignore
     identifier: external_gene_identifier.SavedExternalGeneIdentifier
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/keyword.py
+++ b/src/mavedb/view_models/keyword.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Optional
 
 from mavedb.lib.validation import keywords
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 
 
@@ -45,6 +46,10 @@ class KeywordUpdate(KeywordBase):
 
 class SavedKeyword(KeywordBase):
     """Base class for keyword view models representing saved records."""
+
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/license.py
+++ b/src/mavedb/view_models/license.py
@@ -1,6 +1,7 @@
 from datetime import date
 from typing import Optional
 
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel
 
 
@@ -18,6 +19,9 @@ class SavedLicense(LicenseBase):
     """Base class for license view models representing saved records."""
 
     id: int
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/mapped_variant.py
+++ b/src/mavedb/view_models/mapped_variant.py
@@ -1,7 +1,8 @@
 from datetime import date
 from typing import Any, Optional
 
-from .base.base import BaseModel
+from mavedb.view_models import record_type_validator, set_record_type
+from mavedb.view_models.base.base import BaseModel
 
 
 class MappedVariantBase(BaseModel):
@@ -27,6 +28,9 @@ class MappedVariantUpdate(MappedVariantBase):
 # Properties shared by models stored in DB
 class SavedMappedVariant(MappedVariantBase):
     id: int
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/orcid.py
+++ b/src/mavedb/view_models/orcid.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel
 
 
@@ -16,6 +17,9 @@ class OrcidAuthTokenResponse(BaseModel):
 
 
 class OrcidUser(BaseModel):
+    record_type: str = None  # type: ignore
     orcid_id: str
     given_name: Optional[str]
     family_name: Optional[str]
+
+    _record_type_factory = record_type_validator()(set_record_type)

--- a/src/mavedb/view_models/publication_identifier.py
+++ b/src/mavedb/view_models/publication_identifier.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from mavedb.lib.identifiers import PublicationAuthors
 from mavedb.lib.validation.publication import validate_db_name, validate_publication
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ class PublicationIdentifierCreate(PublicationIdentifierBase):
 
 # Properties of external publication identifiers
 class ExternalPublicationIdentifier(PublicationIdentifierBase):
+    record_type: str = None  # type: ignore
     title: str
     authors: list[PublicationAuthors]
 
@@ -36,6 +38,8 @@ class ExternalPublicationIdentifier(PublicationIdentifierBase):
     publication_journal: Optional[str]
     url: Optional[str]
     reference_html: Optional[str]
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/raw_read_identifier.py
+++ b/src/mavedb/view_models/raw_read_identifier.py
@@ -1,3 +1,4 @@
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel
 
 
@@ -12,7 +13,10 @@ class RawReadIdentifierCreate(RawReadIdentifierBase):
 # Properties shared by models stored in DB
 class SavedRawReadIdentifier(RawReadIdentifierBase):
     id: int
+    record_type: str = None  # type: ignore
     url: str
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -13,7 +13,7 @@ from mavedb.lib.validation.exceptions import ValidationError
 from mavedb.lib.validation.utilities import inf_or_float, is_null
 from mavedb.models.enums.mapping_state import MappingState
 from mavedb.models.enums.processing_state import ProcessingState
-from mavedb.view_models import PublicationIdentifiersGetter
+from mavedb.view_models import PublicationIdentifiersGetter, record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 from mavedb.view_models.contributor import Contributor, ContributorCreate
 from mavedb.view_models.doi_identifier import (
@@ -342,6 +342,9 @@ class ShortScoreSet(BaseModel):
     modification_date: date
     target_genes: list[ShortTargetGene]
     private: bool
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True
@@ -351,6 +354,9 @@ class ShortScoreSet(BaseModel):
 
 class ShorterScoreSet(BaseModel):
     urn: str
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True
@@ -361,6 +367,7 @@ class ShorterScoreSet(BaseModel):
 class SavedScoreSet(ScoreSetBase):
     """Base class for score set view models representing saved records."""
 
+    record_type: str = None  # type: ignore
     urn: str
     num_variants: int
     license: ShortLicense
@@ -381,6 +388,8 @@ class SavedScoreSet(ScoreSetBase):
     external_links: Dict[str, ExternalLink]
     contributors: list[Contributor]
     score_ranges: Optional[ScoreRanges]
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/target_accession.py
+++ b/src/mavedb/view_models/target_accession.py
@@ -1,6 +1,7 @@
 from datetime import date
 from typing import Optional
 
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 
 
@@ -31,6 +32,10 @@ class TargetAccessionUpdate(TargetAccessionModify):
 
 # Properties shared by models stored in DB
 class SavedTargetAccession(TargetAccessionBase):
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
+
     class Config:
         orm_mode = True
         arbitrary_types_allowed = True

--- a/src/mavedb/view_models/target_gene.py
+++ b/src/mavedb/view_models/target_gene.py
@@ -5,7 +5,7 @@ from pydantic import root_validator
 from pydantic.utils import GetterDict
 
 from mavedb.lib.validation import target
-from mavedb.view_models import external_gene_identifier_offset
+from mavedb.view_models import external_gene_identifier_offset, record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 from mavedb.view_models.target_accession import SavedTargetAccession, TargetAccession, TargetAccessionCreate
 from mavedb.view_models.target_sequence import (
@@ -82,9 +82,12 @@ class SavedTargetGene(TargetGeneBase):
     """Base class for target gene view models representing saved records."""
 
     id: int
+    record_type: str = None  # type: ignore
     target_sequence: Optional[SavedTargetSequence]
     target_accession: Optional[SavedTargetAccession]
     external_identifiers: Sequence[external_gene_identifier_offset.SavedExternalGeneIdentifierOffset]
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/target_sequence.py
+++ b/src/mavedb/view_models/target_sequence.py
@@ -5,6 +5,7 @@ from fqfa import infer_sequence_type
 
 from mavedb.lib.validation import target
 from mavedb.lib.validation.exceptions import ValidationError
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 from mavedb.view_models.taxonomy import AdminTaxonomy, SavedTaxonomy, Taxonomy, TaxonomyCreate
 
@@ -66,7 +67,10 @@ class TargetSequenceUpdate(TargetSequenceModify):
 
 # Properties shared by models stored in DB
 class SavedTargetSequence(TargetSequenceBase):
+    record_type: str = None  # type: ignore
     taxonomy: SavedTaxonomy
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/taxonomy.py
+++ b/src/mavedb/view_models/taxonomy.py
@@ -2,7 +2,8 @@ from datetime import date
 
 from pydantic.types import Optional
 
-from .base.base import BaseModel
+from mavedb.view_models import record_type_validator, set_record_type
+from mavedb.view_models.base.base import BaseModel
 
 
 class TaxonomyBase(BaseModel):
@@ -26,7 +27,10 @@ class TaxonomyUpdate(TaxonomyBase):
 # Properties shared by models stored in DB
 class SavedTaxonomy(TaxonomyBase):
     id: int
+    record_type: str = None  # type: ignore
     url: str
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/user.py
+++ b/src/mavedb/view_models/user.py
@@ -5,6 +5,7 @@ from pydantic import Field
 
 from mavedb.lib.validation.exceptions import ValidationError
 from mavedb.models.enums.user_role import UserRole
+from mavedb.view_models import record_type_validator, set_record_type
 from mavedb.view_models.base.base import BaseModel, validator
 
 
@@ -49,6 +50,10 @@ class AdminUserUpdate(CurrentUserUpdate):
 
 class SavedUser(UserBase):
     """Base class for user view models representing saved records."""
+
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/src/mavedb/view_models/variant.py
+++ b/src/mavedb/view_models/variant.py
@@ -3,7 +3,8 @@ from typing import Any
 
 from pydantic.types import Optional
 
-from .base.base import BaseModel
+from mavedb.view_models import record_type_validator, set_record_type
+from mavedb.view_models.base.base import BaseModel
 
 
 class VariantBase(BaseModel):
@@ -28,6 +29,9 @@ class VariantUpdate(VariantBase):
 # Properties shared by models stored in DB
 class VariantInDbBase(VariantBase):
     id: int
+    record_type: str = None  # type: ignore
+
+    _record_type_factory = record_type_validator()(set_record_type)
 
     class Config:
         orm_mode = True

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -167,16 +167,19 @@ TEST_MINIMAL_EXPERIMENT = {
 }
 
 TEST_MINIMAL_EXPERIMENT_RESPONSE = {
+    "recordType": "Experiment",
     "title": "Test Experiment Title",
     "shortDescription": "Test experiment",
     "abstractText": "Abstract",
     "methodText": "Methods",
     "createdBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
     },
     "modifiedBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
@@ -196,16 +199,19 @@ TEST_MINIMAL_EXPERIMENT_RESPONSE = {
 }
 
 TEST_EXPERIMENT_WITH_KEYWORD_RESPONSE = {
+    "recordType": "Experiment",
     "title": "Test Experiment Title",
     "shortDescription": "Test experiment",
     "abstractText": "Abstract",
     "methodText": "Methods",
     "createdBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
     },
     "modifiedBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
@@ -216,6 +222,7 @@ TEST_EXPERIMENT_WITH_KEYWORD_RESPONSE = {
     "contributors": [],
     "keywords": [
         {
+            "recordType": "ExperimentControlledKeyword",
             "keyword": {"key": "Delivery method", "value": "Other", "special": False, "description": "Description"},
             "description": "Details of delivery method",
         },
@@ -230,16 +237,19 @@ TEST_EXPERIMENT_WITH_KEYWORD_RESPONSE = {
 }
 
 TEST_EXPERIMENT_WITH_KEYWORD_HAS_DUPLICATE_OTHERS_RESPONSE = {
+    "recordType": "Experiment",
     "title": "Test Experiment Title",
     "shortDescription": "Test experiment",
     "abstractText": "Abstract",
     "methodText": "Methods",
     "createdBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
     },
     "modifiedBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
@@ -250,6 +260,7 @@ TEST_EXPERIMENT_WITH_KEYWORD_HAS_DUPLICATE_OTHERS_RESPONSE = {
     "contributors": [],
     "keywords": [
         {
+            "recordType": "ExperimentControlledKeyword",
             "keyword": {
                 "key": "Variant Library Creation Method",
                 "value": "Other",
@@ -259,6 +270,7 @@ TEST_EXPERIMENT_WITH_KEYWORD_HAS_DUPLICATE_OTHERS_RESPONSE = {
             "description": "Description",
         },
         {
+            "recordType": "ExperimentControlledKeyword",
             "keyword": {"key": "Delivery method", "value": "Other", "special": False, "description": "Description"},
             "description": "Description",
         },
@@ -348,35 +360,44 @@ TEST_MINIMAL_SEQ_SCORESET = {
 }
 
 TEST_MINIMAL_SEQ_SCORESET_RESPONSE = {
+    "recordType": "ScoreSet",
     "title": "Test Score Set Title",
     "shortDescription": "Test score set",
     "abstractText": "Abstract",
     "methodText": "Methods",
     "createdBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
     },
     "modifiedBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
     },
     "creationDate": date.today().isoformat(),
     "modificationDate": date.today().isoformat(),
-    "license": {camelize(k): v for k, v in TEST_LICENSE.items() if k not in ("text",)},
+    "license": {
+        "recordType": "ShortLicense",
+        **{camelize(k): v for k, v in TEST_LICENSE.items() if k not in ("text",)},
+    },
     "numVariants": 0,
     "targetGenes": [
         {
+            "recordType": "TargetGene",
             "name": "TEST1",
             "category": "Protein coding",
             "externalIdentifiers": [],
             "id": 1,
             "targetSequence": {
+                "recordType": "TargetSequence",
                 "sequenceType": "dna",
                 "sequence": "ACGTTT",
                 "label": "TEST1",
                 "taxonomy": {
+                    "recordType": "Taxonomy",
                     "taxId": TEST_TAXONOMY["tax_id"],
                     "organismName": TEST_TAXONOMY["organism_name"],
                     "commonName": TEST_TAXONOMY["common_name"],
@@ -436,30 +457,42 @@ TEST_ACC_SCORESET = {
 }
 
 TEST_MINIMAL_ACC_SCORESET_RESPONSE = {
+    "recordType": "ScoreSet",
     "title": "Test Score Set Acc Title",
     "shortDescription": "Test accession score set",
     "abstractText": "Abstract",
     "methodText": "Methods",
     "createdBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
     },
     "modifiedBy": {
+        "recordType": "User",
         "firstName": TEST_USER["first_name"],
         "lastName": TEST_USER["last_name"],
         "orcidId": TEST_USER["username"],
     },
     "creationDate": date.today().isoformat(),
     "modificationDate": date.today().isoformat(),
-    "license": {camelize(k): v for k, v in TEST_LICENSE.items() if k not in ("text",)},
+    "license": {
+        "recordType": "ShortLicense",
+        **{camelize(k): v for k, v in TEST_LICENSE.items() if k not in ("text",)},
+    },
     "numVariants": 0,
     "targetGenes": [
         {
+            "recordType": "TargetGene",
             "name": "TEST2",
             "category": "Protein coding",
             "externalIdentifiers": [],
-            "targetAccession": {"accession": VALID_ACCESSION, "assembly": "GRCh37", "gene": VALID_GENE},
+            "targetAccession": {
+                "recordType": "TargetAccession",
+                "accession": VALID_ACCESSION,
+                "assembly": "GRCh37",
+                "gene": VALID_GENE,
+            },
         }
     ],
     "metaAnalyzesScoreSetUrns": [],

--- a/tests/routers/test_experiments.py
+++ b/tests/routers/test_experiments.py
@@ -74,6 +74,7 @@ def test_create_experiment_with_contributor(client, setup_router_db):
     expected_response.update({"urn": response_data["urn"], "experimentSetUrn": response_data["experimentSetUrn"]})
     expected_response["contributors"] = [
         {
+            "recordType": "Contributor",
             "orcidId": TEST_ORCID_ID,
             "givenName": "ORCID",
             "familyName": "User",
@@ -723,6 +724,7 @@ def test_create_experiment_with_new_primary_pubmed_publication(client, setup_rou
             "identifier",
             "title",
             "url",
+            "recordType",
             "referenceHtml",
             "publicationJournal",
             "publicationYear",
@@ -753,6 +755,7 @@ def test_create_experiment_with_new_primary_preprint_publication(client, setup_r
             "identifier",
             "title",
             "url",
+            "recordType",
             "referenceHtml",
             "doi",
             "publicationJournal",
@@ -783,6 +786,7 @@ def test_create_experiment_with_new_primary_crossref_publication(client, setup_r
             "identifier",
             "title",
             "url",
+            "recordType",
             "referenceHtml",
             "doi",
             "publicationJournal",

--- a/tests/routers/test_score_set.py
+++ b/tests/routers/test_score_set.py
@@ -90,6 +90,7 @@ def test_create_score_set_with_contributor(client, setup_router_db):
     )
     expected_response["contributors"] = [
         {
+            "recordType": "Contributor",
             "orcidId": TEST_ORCID_ID,
             "givenName": "ORCID",
             "familyName": "User",
@@ -238,17 +239,20 @@ def test_contributor_can_get_other_users_private_score_set(session, client, setu
     )
     expected_response["contributors"] = [
         {
+            "recordType": "Contributor",
             "orcidId": TEST_USER["username"],
             "givenName": TEST_USER["first_name"],
             "familyName": TEST_USER["last_name"],
         }
     ]
     expected_response["createdBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],
     }
     expected_response["modifiedBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],
@@ -424,17 +428,20 @@ def test_contributor_can_add_scores_to_other_user_score_set(session, client, set
     score_set.update({"processingState": "processing"})
     score_set["contributors"] = [
         {
+            "recordType": "Contributor",
             "orcidId": TEST_USER["username"],
             "givenName": TEST_USER["first_name"],
             "familyName": TEST_USER["last_name"],
         }
     ]
     score_set["createdBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],
     }
     score_set["modifiedBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],
@@ -480,17 +487,20 @@ def test_contributor_can_add_scores_and_counts_to_other_user_score_set(session, 
     score_set.update({"processingState": "processing"})
     score_set["contributors"] = [
         {
+            "recordType": "Contributor",
             "orcidId": TEST_USER["username"],
             "givenName": TEST_USER["first_name"],
             "familyName": TEST_USER["last_name"],
         }
     ]
     score_set["createdBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],
     }
     score_set["modifiedBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],
@@ -705,17 +715,20 @@ def test_contributor_can_publish_other_users_score_set(session, data_provider, c
     )
     expected_response["contributors"] = [
         {
+            "recordType": "Contributor",
             "orcidId": TEST_USER["username"],
             "givenName": TEST_USER["first_name"],
             "familyName": TEST_USER["last_name"],
         }
     ]
     expected_response["createdBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],
     }
     expected_response["modifiedBy"] = {
+        "recordType": "User",
         "orcidId": EXTRA_USER["username"],
         "firstName": EXTRA_USER["first_name"],
         "lastName": EXTRA_USER["last_name"],


### PR DESCRIPTION
Client level views will now receive a `recordType` field, which indicates the name of the view model that was used to generate the output.

I considered adding this to the base model, but really these should only be defined on models returned to the client. There's some boiler plate here, but if we were to reduce the boiler plate by defining this property on the Pydantic base class our API documentation would imply users need to supply a `recordType` property within resources posted to our API. The additional code duplication seems well worth it to maintain our documentations' consistency.