### PR TITLE
Additional Statistics Endpoints and Statistics Router Refactor

### DIFF
--- a/src/mavedb/routers/statistics.py
+++ b/src/mavedb/routers/statistics.py
@@ -1,10 +1,10 @@
 import itertools
 from collections import OrderedDict
 from enum import Enum
-from typing import Union, Optional
+from typing import Any, Union, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import Table, func, select
+from sqlalchemy import Table, func, select, Select
 from sqlalchemy.orm import Session
 
 from mavedb.deps import get_db
@@ -43,27 +43,20 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
+TARGET_ACCESSION_TAXONOMY = "Homo sapiens"
+
+## Union types
+
+RecordModels = Union[type[Experiment], type[ScoreSet]]
+RecordAssociationTables = Union[
+    Table,
+    type[ExperimentControlledKeywordAssociation],
+    type[ExperimentPublicationIdentifierAssociation],
+    type[ScoreSetPublicationIdentifierAssociation],
+]
+
+
 ## Enum classes hold valid endpoints for different statistics routes.
-
-
-class TargetGeneFields(str, Enum):
-    category = "category"
-    organism = "organism"
-
-    ensemblIdentifier = "ensembl-identifier"
-    refseqIdentifier = "refseq-identifier"
-    uniprotIdentifier = "uniprot-identifier"
-
-
-class TargetAccessionFields(str, Enum):
-    accession = "accession"
-    assembly = "assembly"
-    gene = "gene"
-
-
-class TargetSequenceFields(str, Enum):
-    sequence = "sequence"
-    sequenceType = "sequence-type"
 
 
 class RecordNames(str, Enum):
@@ -84,166 +77,21 @@ class GroupBy(str, Enum):
     year = "year"
 
 
-def _target_from_field_and_model(
-    db: Session,
-    model: Union[type[TargetAccession], type[TargetSequence]],
-    field: Union[TargetAccessionFields, TargetSequenceFields],
-):
+def _model_and_association_from_record_field(
+    record: RecordNames, field: Optional[RecordFields]
+) -> tuple[RecordModels, Optional[RecordAssociationTables]]:
     """
-    Given either the target accession or target sequence model, generate counts that can be used to create
-    a statistic for those fields.
-    """
-    # Protection from this case occurs via FastApi/pydantic Enum validation on endpoints that reference this function.
-    # If we are careful with our enumeration definitons, we should not end up here.
-    if (model == TargetAccession and field not in TargetAccessionFields) or (
-        model == TargetSequence and field not in TargetSequenceFields
-    ):
-        raise HTTPException(422, f"Field `{field.name}` is incompatible with target model `{model}`.")
-
-    published_score_sets_stmt = select(ScoreSet).where(ScoreSet.published_date.is_not(None)).subquery()
-
-    # getattr obscures MyPy errors by coercing return type to Any
-    model_field = field.value.replace("-", "_")
-    column_field = getattr(model, model_field)
-    query = (
-        select(column_field, func.count(column_field))
-        .join(TargetGene)
-        .group_by(column_field)
-        .join_from(TargetGene, published_score_sets_stmt)
-    )
-
-    return db.execute(query).all()
-
-
-# Accession based targets only.
-@router.get("/target/accession/{field}", status_code=200, response_model=dict[str, int])
-def target_accessions_by_field(field: TargetAccessionFields, db: Session = Depends(get_db)) -> dict[str, int]:
-    """
-    Returns a dictionary of counts for the distinct values of the provided `field` (member of the `target_accessions` table).
-    Don't include any NULL field values.
-    """
-    return {
-        field_val: count
-        for field_val, count in _target_from_field_and_model(db, TargetAccession, field)
-        if field_val is not None
-    }
-
-
-# Sequence based targets only.
-@router.get("/target/sequence/{field}", status_code=200, response_model=dict[str, int])
-def target_sequences_by_field(field: TargetSequenceFields, db: Session = Depends(get_db)) -> dict[str, int]:
-    """
-    Returns a dictionary of counts for the distinct values of the provided `field` (member of the `target_sequences` table).
-    Don't include any NULL field values.
-    """
-    return {
-        field_val: count
-        for field_val, count in _target_from_field_and_model(db, TargetSequence, field)
-        if field_val is not None
-    }
-
-
-# Statistics on fields relevant to both accession and sequence based targets. Generally, these require custom logic to harmonize both target sub types.
-@router.get("/target/gene/{field}", status_code=200, response_model=dict[str, int])
-def target_genes_by_field(field: TargetGeneFields, db: Session = Depends(get_db)) -> dict[str, int]:
-    """
-    Returns a dictionary of counts for the distinct values of the provided `field` (member of the `target_sequences` table).
-    Don't include any NULL field values. Each field here is handled individually because of the unique structure of this
-    target gene object- fields might require information from both TargetGene subtypes (accession and sequence).
-    """
-    association_tables: dict[TargetGeneFields, Union[type[EnsemblOffset], type[RefseqOffset], type[UniprotOffset]]] = {
-        TargetGeneFields.ensemblIdentifier: EnsemblOffset,
-        TargetGeneFields.refseqIdentifier: RefseqOffset,
-        TargetGeneFields.uniprotIdentifier: UniprotOffset,
-    }
-    identifier_models: dict[
-        TargetGeneFields, Union[type[EnsemblIdentifier], type[RefseqIdentifier], type[UniprotIdentifier]]
-    ] = {
-        TargetGeneFields.ensemblIdentifier: EnsemblIdentifier,
-        TargetGeneFields.refseqIdentifier: RefseqIdentifier,
-        TargetGeneFields.uniprotIdentifier: UniprotIdentifier,
-    }
-
-    # All targets linked to a published score set.
-    published_score_sets_stmt = select(TargetGene).join(ScoreSet).where(ScoreSet.published_date.is_not(None)).subquery()
-
-    # Assumes identifiers cannot be duplicated within a Target.
-    if field in identifier_models.keys():
-        # getattr obscures MyPy errors by coercing return type to Any
-        attr_for_identifier = getattr(identifier_models[field], "identifier")
-
-        query = (
-            select(attr_for_identifier, func.count(attr_for_identifier))
-            .join(association_tables[field])
-            .join(published_score_sets_stmt)
-            .group_by(attr_for_identifier)
-        )
-
-        return {identifier: count for identifier, count in db.execute(query).all() if identifier is not None}
-
-    # Can't join a TargetGene query to TargetGene query, so just select the desired columns directly from the subquery.
-    elif field is TargetGeneFields.category:
-        query = select(published_score_sets_stmt.c.category, func.count(published_score_sets_stmt.c.category)).group_by(
-            published_score_sets_stmt.c.category
-        )
-
-        return {category: count for category, count in db.execute(query).all() if category is not None}
-
-    # Target gene organism needs special handling: it is stored differently between accession and sequence Targets.
-    elif field is TargetGeneFields.organism:
-        sequence_based_targets_query = (
-            select(Taxonomy.organism_name, func.count(Taxonomy.organism_name))
-            .join(TargetSequence)
-            .join(published_score_sets_stmt)
-            .group_by(Taxonomy.organism_name)
-        )
-        accession_based_targets_query = select(func.count(TargetAccession.id)).join(published_score_sets_stmt)
-
-        organisms: dict[str, int] = {
-            organism: count
-            for organism, count in db.execute(sequence_based_targets_query).all()
-            if organism is not None
-        }
-        accession_count = db.execute(accession_based_targets_query).scalar_one_or_none()
-
-        # NOTE: For now (forever?), all accession based targets are human genomic sequences. It is possible this
-        #       assumption changes if we add mouse (or other non-human) genomes to MaveDB.
-        if "Homo sapiens" in organisms and accession_count:
-            organisms["Homo sapiens"] += accession_count
-        elif accession_count:
-            organisms["Homo sapiens"] = accession_count
-
-        return organisms
-
-    # Protection from this case occurs via FastApi/pydantic Enum validation.
-    else:
-        raise ValueError(f"Unknown field: {field}")
-
-
-def _record_from_field_and_model(
-    db: Session,
-    model: RecordNames,
-    field: RecordFields,
-):
-    """
-    Given a member of the RecordNames and RecordFields Enums, generate counts that can be used to create a
-    statistic for those enums.
+    Given a member of the RecordNames and RecordFields Enums, generate the model and association table that can be used
+    to generate statistics for those fields.
 
     This function should be used for generating statistics for fields shared between Experiments and Score Sets.
     If necessary, Experiment Sets can be handled in a similar manner in the future.
     """
-    association_tables: dict[
-        RecordNames,
-        dict[
-            RecordFields,
-            Union[
-                Table,
-                type[ExperimentControlledKeywordAssociation],
-                type[ExperimentPublicationIdentifierAssociation],
-                type[ScoreSetPublicationIdentifierAssociation],
-            ],
-        ],
-    ] = {
+    record_to_model_map: dict[RecordNames, RecordModels] = {
+        RecordNames.experiment: Experiment,
+        RecordNames.scoreSet: ScoreSet,
+    }
+    record_to_assc_map: dict[RecordNames, dict[RecordFields, RecordAssociationTables]] = {
         RecordNames.experiment: {
             RecordFields.doiIdentifiers: experiments_doi_identifiers_association_table,
             RecordFields.publicationIdentifiers: ExperimentPublicationIdentifierAssociation,
@@ -257,115 +105,161 @@ def _record_from_field_and_model(
         },
     }
 
-    models: dict[RecordNames, Union[type[Experiment], type[ScoreSet]]] = {
-        RecordNames.experiment: Experiment,
-        RecordNames.scoreSet: ScoreSet,
-    }
+    queried_model = record_to_model_map[record]
+    queried_model_assc = record_to_assc_map[record]
 
-    queried_model = models[model]
+    if field is None or field not in queried_model_assc:
+        return queried_model, None
 
-    # created-by field does not operate on association tables and is defined directly on score set / experiment
-    # records, so we operate directly on those records.
-    # getattr obscures MyPy errors by coercing return type to Any
-    model_created_by_field = getattr(queried_model, "created_by_id")
-    model_published_data_field = getattr(queried_model, "published_date")
-    if field is RecordFields.createdBy:
-        query = (
-            select(User.username, func.count(User.id))
-            .join(queried_model, model_created_by_field == User.id)
-            .where(model_published_data_field.is_not(None))
-            .group_by(User.id)
-        )
-
-        return db.execute(query).all()
-    else:
-        # All assc table identifiers which are linked to a published model.
-        queried_assc_table = association_tables[model][field]
-        published_score_sets_statement = (
-            select(queried_assc_table).join(queried_model).where(model_published_data_field.is_not(None)).subquery()
-        )
-
-    # Assumes any identifiers / keywords may not be duplicated within a record.
-    if field is RecordFields.doiIdentifiers:
-        query = select(DoiIdentifier.identifier, func.count(DoiIdentifier.identifier)).group_by(
-            DoiIdentifier.identifier
-        )
-    elif field is RecordFields.keywords:
-        query = select(ControlledKeyword.value, func.count(ControlledKeyword.value)).group_by(ControlledKeyword.value)
-    elif field is RecordFields.rawReadIdentifiers:
-        query = select(RawReadIdentifier.identifier, func.count(RawReadIdentifier.identifier)).group_by(
-            RawReadIdentifier.identifier
-        )
-
-    # Handle publication identifiers separately since they may have duplicated identifiers
-    elif field is RecordFields.publicationIdentifiers:
-        publication_query = (
-            select(
-                PublicationIdentifier.identifier,
-                PublicationIdentifier.db_name,
-                func.count(PublicationIdentifier.identifier),
-            )
-            .join(published_score_sets_statement)
-            .group_by(PublicationIdentifier.identifier, PublicationIdentifier.db_name)
-        )
-
-        publication_identifiers: dict[str, dict[str, int]] = {}
-
-        for identifier, db_name, count in db.execute(publication_query).all():
-            # We don't need to worry about overwriting existing identifiers within these internal dictionaries because
-            # of the SQL group by clause.
-            if db_name in publication_identifiers:
-                publication_identifiers[db_name][identifier] = count
-            else:
-                publication_identifiers[db_name] = {identifier: count}
-
-        return [(db_name, identifiers) for db_name, identifiers in publication_identifiers.items()]
-
-    # Protection from this case occurs via FastApi/pydantic Enum validation on methods which reference this one.
-    else:
-        return []
-
-    return db.execute(query.join(published_score_sets_statement)).all()
+    return queried_model, queried_model_assc[field]
 
 
-# Model based statistics for shared fields.
-#
-# NOTE: If custom logic is needed for record models with more specific endpoint paths,
-#       i.e. non-shared fields, define them above this route so as not to obscure them.
-@router.get("/record/{model}/{field}", status_code=200, response_model=Union[dict[str, int], dict[str, dict[str, int]]])
-def record_object_statistics(
-    model: RecordNames, field: RecordFields, db: Session = Depends(get_db)
+def _join_model_and_filter_unpublished(query: Select, model: RecordModels) -> Select:
+    return query.join(model).where(model.published_date.is_not(None))
+
+
+def _count_for_identifier_in_query(db: Session, query: Select[tuple[Any, int]]) -> dict[Any, int]:
+    return {value: count for value, count in db.execute(query).all() if value is not None}
+
+
+########################################################################################
+#  Record statistics
+########################################################################################
+
+
+@router.get(
+    "/record/{record}/keywords", status_code=200, response_model=Union[dict[str, int], dict[str, dict[str, int]]]
+)
+def experiment_keyword_statistics(
+    record: RecordNames, db: Session = Depends(get_db)
 ) -> Union[dict[str, int], dict[str, dict[str, int]]]:
     """
-    Resolve a dictionary of statistics based on the provided model name and model field.
-
-    Model names and fields should be members of the Enum classes defined above. Providing an invalid model name or
-    model field will yield a 422 Unprocessable Entity error with details about valid enum values.
+    Returns a dictionary of counts for the distinct values of the `value` field (member of the `controlled_keywords` table).
+    Don't include any NULL field values. Don't include any keywords from unpublished experiments.
     """
-    # Validation to ensure 'keywords' is only used with 'experiment'.
-    if model == RecordNames.scoreSet and field == RecordFields.keywords:
+    if record == RecordNames.scoreSet:
         raise HTTPException(
-            status_code=422, detail="The 'keywords' field can only be used with the 'experiment' model."
+            422,
+            "The 'keywords' field can only be used with the 'experiment' model. Score sets do not have associated keywords.",
         )
 
-    count_data = _record_from_field_and_model(db, model, field)
+    queried_model, queried_assc = _model_and_association_from_record_field(record, RecordFields.keywords)
 
-    return {field_val: count for field_val, count in count_data if field_val is not None}
+    if queried_assc is None:
+        raise HTTPException(500, "No association table associated with the keywords field when one was expected.")
+
+    query = _join_model_and_filter_unpublished(
+        select(ControlledKeyword.value, func.count(ControlledKeyword.value)).join(queried_assc), queried_model
+    ).group_by(ControlledKeyword.value)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/record/{record}/publication-identifiers", status_code=200, response_model=dict[str, dict[str, int]])
+def experiment_publication_identifier_statistics(
+    record: RecordNames, db: Session = Depends(get_db)
+) -> dict[str, dict[str, int]]:
+    """
+    Returns a dictionary of counts for the distinct values of the `identifier` field (member of the `publication_identifiers` table).
+    Don't include any publication identifiers from unpublished experiments.
+    """
+    queried_model, queried_assc = _model_and_association_from_record_field(record, RecordFields.publicationIdentifiers)
+
+    if queried_assc is None:
+        raise HTTPException(
+            500, "No association table associated with the publication identifiers field when one was expected."
+        )
+
+    query = _join_model_and_filter_unpublished(
+        select(
+            PublicationIdentifier.identifier,
+            PublicationIdentifier.db_name,
+            func.count(PublicationIdentifier.identifier),
+        ).join(queried_assc),
+        queried_model,
+    ).group_by(PublicationIdentifier.identifier, PublicationIdentifier.db_name)
+
+    publication_identifiers: dict[str, dict[str, int]] = {}
+
+    for identifier, db_name, count in db.execute(query).all():
+        # We don't need to worry about overwriting existing identifiers within these internal dictionaries because
+        # of the SQL group by clause.
+        if db_name in publication_identifiers:
+            publication_identifiers[db_name][identifier] = count
+        else:
+            publication_identifiers[db_name] = {identifier: count}
+
+    return publication_identifiers
+
+
+@router.get("/record/{record}/raw-read-identifiers", status_code=200, response_model=dict[str, int])
+def experiment_raw_read_identifier_statistics(record: RecordNames, db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `identifier` field (member of the `raw_read_identifiers` table).
+    Don't include any raw read identifiers from unpublished experiments.
+    """
+    queried_model, queried_assc = _model_and_association_from_record_field(record, RecordFields.rawReadIdentifiers)
+
+    if queried_assc is None:
+        raise HTTPException(
+            500, "No association table associated with the raw read identifiers field when one was expected."
+        )
+
+    query = _join_model_and_filter_unpublished(
+        select(RawReadIdentifier.identifier, func.count(RawReadIdentifier.identifier)).join(queried_assc), queried_model
+    ).group_by(RawReadIdentifier.identifier)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/record/{record}/doi-identifiers", status_code=200, response_model=dict[str, int])
+def experiment_doi_identifiers_statistics(record: RecordNames, db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `identifier` field (member of the `doi_identifiers` table).
+    Don't include any DOI identifiers from unpublished experiments.
+    """
+    queried_model, queried_assc = _model_and_association_from_record_field(record, RecordFields.doiIdentifiers)
+
+    if queried_assc is None:
+        raise HTTPException(
+            500, "No association table associated with the doi identifiers field when one was expected."
+        )
+
+    query = _join_model_and_filter_unpublished(
+        select(DoiIdentifier.identifier, func.count(DoiIdentifier.identifier)).join(queried_assc), queried_model
+    ).group_by(DoiIdentifier.identifier)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/record/{record}/created-by", status_code=200, response_model=dict[str, int])
+def experiment_created_by_statistics(record: RecordNames, db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `username` field (member of the `users` table).
+    Don't include any usernames from unpublished experiments.
+    """
+    queried_model, queried_assc = _model_and_association_from_record_field(record, RecordFields.createdBy)
+
+    query = (
+        select(User.username, func.count(User.id))
+        .join(queried_model, queried_model.created_by_id == User.id)
+        .filter(queried_model.published_date.is_not(None))
+        .group_by(User.id)
+    )
+
+    return _count_for_identifier_in_query(db, query)
 
 
 @router.get("/record/{model}/published/count", status_code=200, response_model=dict[str, int])
 def record_counts(model: RecordNames, group: Optional[GroupBy] = None, db: Session = Depends(get_db)) -> dict[str, int]:
     """
-    Returns a dictionary of counts for the number of records in each table.
+    Returns a dictionary of counts for the number of published records of the `model` parameter.
+    Optionally, group the counts by the published month or year.
     """
-    models: dict[RecordNames, Union[type[Experiment], type[ScoreSet]]] = {
-        RecordNames.experiment: Experiment,
-        RecordNames.scoreSet: ScoreSet,
-    }
+    queried_model, queried_assc = _model_and_association_from_record_field(model, None)
 
-    queried_model = models[model]
-
-    # Protects against Nonetype publication dates with where clause and ignore mypy typing errors in dictcomps.
+    # Protect against Nonetype publication dates with where clause.
+    # We can safely ignore Mypy Nonetype errors in the following dictcomps.
     objs = db.scalars(
         select(queried_model.published_date)
         .where(queried_model.published_date.isnot(None))
@@ -380,3 +274,173 @@ def record_counts(model: RecordNames, group: Optional[GroupBy] = None, db: Sessi
         grouped = {"all": len(objs)}
 
     return OrderedDict(sorted(grouped.items()))
+
+
+########################################################################################
+# Target statistics
+########################################################################################
+
+
+##### Accession based targets #####
+
+
+@router.get("/target/accession/accession", status_code=200, response_model=dict[str, int])
+def target_accessions_accession_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `accession` field (member of the `target_accessions` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(TargetAccession.accession, func.count(TargetAccession.accession)).join(TargetGene), ScoreSet
+    ).group_by(TargetAccession.accession)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/target/accession/assembly", status_code=200, response_model=dict[str, int])
+def target_accessions_assembly_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `assembly` field (member of the `target_accessions` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(TargetAccession.assembly, func.count(TargetAccession.assembly)).join(TargetGene), ScoreSet
+    ).group_by(TargetAccession.assembly)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/target/accession/gene", status_code=200, response_model=dict[str, int])
+def target_accessions_gene_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `gene` field (member of the `target_accessions` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(TargetAccession.gene, func.count(TargetAccession.gene)).join(TargetGene), ScoreSet
+    ).group_by(TargetAccession.gene)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+##### Sequence based targets #####
+
+
+@router.get("/target/sequence/sequence", status_code=200, response_model=dict[str, int])
+def target_sequences_sequence_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `sequence` field (member of the `target_sequences` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(TargetSequence.sequence, func.count(TargetSequence.sequence)).join(TargetGene), ScoreSet
+    ).group_by(TargetSequence.sequence)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/target/sequence/sequence-type", status_code=200, response_model=dict[str, int])
+def target_sequences_sequence_type_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `sequence_type` field (member of the `target_sequences` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(TargetSequence.sequence_type, func.count(TargetSequence.sequence_type)).join(TargetGene), ScoreSet
+    ).group_by(TargetSequence.sequence_type)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+##### Target genes #####
+
+
+@router.get("/target/gene/category", status_code=200, response_model=dict[str, int])
+def target_genes_category_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `category` field (member of the `target_sequences` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(TargetGene.category, func.count(TargetGene.category)), ScoreSet
+    ).group_by(TargetGene.category)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/target/gene/organism", status_code=200, response_model=dict[str, int])
+def target_genes_organism_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `organism` field (member of the `taxonomies` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+
+    NOTE: For now (and perhaps forever), all accession based targets are human genomic sequences (ie: of taxonomy `Homo sapiens`).
+          It is possible this assumption changes if we add mouse (or other non-human) genomes to MaveDB.
+    """
+    target_sequence_query = _join_model_and_filter_unpublished(
+        select(Taxonomy.organism_name, func.count(Taxonomy.organism_name)).join(TargetSequence).join(TargetGene),
+        ScoreSet,
+    ).group_by(Taxonomy.organism_name)
+    target_accession_query = _join_model_and_filter_unpublished(
+        select(func.count(TargetAccession.id)).join(TargetGene), ScoreSet
+    )
+
+    # Ensure the `Homo sapiens` key exists in the organisms counts dictionary.
+    organisms = _count_for_identifier_in_query(db, target_sequence_query)
+    organisms.setdefault(TARGET_ACCESSION_TAXONOMY, 0)
+
+    count_accession_based_targets = db.execute(target_accession_query).scalar_one_or_none()
+    if count_accession_based_targets:
+        organisms[TARGET_ACCESSION_TAXONOMY] += count_accession_based_targets
+    else:
+        organisms.pop(TARGET_ACCESSION_TAXONOMY)
+
+    return organisms
+
+
+@router.get("/target/gene/ensembl-identifier", status_code=200, response_model=dict[str, int])
+def target_genes_ensembl_identifier_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `identifier` field (member of the `ensembl_identifiers` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(EnsemblIdentifier.identifier, func.count(EnsemblIdentifier.identifier))
+        .join(EnsemblOffset)
+        .join(TargetGene),
+        ScoreSet,
+    ).group_by(EnsemblIdentifier.identifier)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/target/gene/refseq-identifier", status_code=200, response_model=dict[str, int])
+def target_genes_refseq_identifier_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `identifier` field (member of the `refseq_identifiers` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(RefseqIdentifier.identifier, func.count(RefseqIdentifier.identifier))
+        .join(RefseqOffset)
+        .join(TargetGene),
+        ScoreSet,
+    ).group_by(RefseqIdentifier.identifier)
+
+    return _count_for_identifier_in_query(db, query)
+
+
+@router.get("/target/gene/uniprot-identifier", status_code=200, response_model=dict[str, int])
+def target_genes_uniprot_identifier_counts(db: Session = Depends(get_db)) -> dict[str, int]:
+    """
+    Returns a dictionary of counts for the distinct values of the `identifier` field (member of the `uniprot_identifiers` table).
+    Don't include any NULL field values. Don't include any targets from unpublished score sets.
+    """
+    query = _join_model_and_filter_unpublished(
+        select(UniprotIdentifier.identifier, func.count(UniprotIdentifier.identifier))
+        .join(UniprotOffset)
+        .join(TargetGene),
+        ScoreSet,
+    ).group_by(UniprotIdentifier.identifier)
+
+    return _count_for_identifier_in_query(db, query)

--- a/src/mavedb/routers/statistics.py
+++ b/src/mavedb/routers/statistics.py
@@ -448,7 +448,6 @@ def target_genes_uniprot_identifier_counts(db: Session = Depends(get_db)) -> dic
     return _count_for_identifier_in_query(db, query)
 
 
-# TODO: Test coverage for this route.
 @router.get("/target/mapped/gene")
 def mapped_target_gene_counts(db: Session = Depends(get_db)) -> dict[str, int]:
     """

--- a/src/mavedb/scripts/mapped_gene_from_mapped_variant.py
+++ b/src/mavedb/scripts/mapped_gene_from_mapped_variant.py
@@ -1,0 +1,126 @@
+import json
+import logging
+import requests
+from typing import Sequence, Optional
+
+import click
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from mavedb.models.score_set import ScoreSet
+from mavedb.models.mapped_variant import MappedVariant
+from mavedb.models.target_gene import TargetGene
+from mavedb.models.variant import Variant
+
+from mavedb.scripts.environment import script_environment, with_database_session
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+CLINGEN_API_URL = "https://reg.test.genome.network/allele"
+
+
+def get_gene_symbol_from_clingen(hgvs_string: str) -> Optional[str]:
+    response = requests.get(f"{CLINGEN_API_URL}?hgvs={hgvs_string}")
+    if response.status_code != 200:
+        logger.error(f"Failed to query ClinGen API for {hgvs_string}: {response.status_code}")
+        return None
+
+    data = response.json()
+    if "aminoAcidAlleles" in data:
+        return data["aminoAcidAlleles"][0].get("geneSymbol")
+    elif "transcriptAlleles" in data:
+        return data["transcriptAlleles"][0].get("geneSymbol")
+
+    return None
+
+
+@script_environment.command()
+@with_database_session
+@click.argument("urns", nargs=-1)
+@click.option("--all", help="Generate gene mappings for every score set in MaveDB.", is_flag=True)
+def generate_gene_mappings(db: Session, urns: Sequence[Optional[str]], all: bool):
+    score_set_ids: Sequence[Optional[int]]
+    if all:
+        score_set_ids = db.scalars(select(ScoreSet.id)).all()
+        logger.info(
+            f"Command invoked with --all. Routine will generate gene mappings for {len(score_set_ids)} score sets."
+        )
+    else:
+        score_set_ids = db.scalars(select(ScoreSet.id).where(ScoreSet.urn.in_(urns))).all()
+        logger.info(f"Generating gene mappings for the provided score sets ({len(score_set_ids)}).")
+
+    for ss_id in score_set_ids:
+        if not ss_id:
+            continue
+
+        score_set = db.scalar(select(ScoreSet).where(ScoreSet.id == ss_id))
+        if not score_set:
+            logger.warning(f"Could not fetch score set with id={ss_id}.")
+            continue
+
+        try:
+            mapped_variant = db.scalars(
+                select(MappedVariant)
+                .join(Variant)
+                .where(
+                    Variant.score_set_id == ss_id,
+                    MappedVariant.current.is_(True),
+                    MappedVariant.post_mapped.isnot(None),
+                )
+                .limit(1)
+            ).one_or_none()
+
+            if not mapped_variant:
+                logger.info(f"No current mapped variant found for score set {score_set.urn}.")
+                continue
+
+            # From line 69, this object must not be None.
+            hgvs_string = mapped_variant.post_mapped.get("expressions", {})[0].get("value")  # type: ignore
+            if not hgvs_string:
+                logger.warning(f"No HGVS string found in post_mapped for variant {mapped_variant.id}.")
+                continue
+
+            gene_symbol = get_gene_symbol_from_clingen(hgvs_string)
+            if not gene_symbol:
+                logger.warning(f"No gene symbol found for HGVS string {hgvs_string}.")
+                continue
+
+            # This script has been designed to work prior to the introduction of multi-target mapping.
+            # This .one() call reflects those assumptions.
+            target_gene = db.scalars(select(TargetGene).where(TargetGene.score_set_id == ss_id)).one()
+
+            if target_gene.post_mapped_metadata is None:
+                logger.warning(
+                    f"Target gene for score set {score_set.urn} has no post_mapped_metadata despite containing current mapped variants."
+                )
+                continue
+
+            # Cannot update JSONB fields directly. They can be converted to dictionaries over Mypy's objections.
+            post_mapped_metadata = json.loads(json.dumps(dict(target_gene.post_mapped_metadata.copy())))  # type: ignore
+            if "genomic" in post_mapped_metadata:
+                key = "genomic"
+            elif "protein" in post_mapped_metadata:
+                key = "protein"
+            else:
+                logger.warning(f"Unknown post_mapped type for variant {mapped_variant.id}.")
+
+            if "sequence_genes" not in post_mapped_metadata[key]:
+                post_mapped_metadata[key]["sequence_genes"] = []
+            post_mapped_metadata[key]["sequence_genes"].append(gene_symbol)
+
+            target_gene.post_mapped_metadata = post_mapped_metadata
+
+            db.add(target_gene)
+            db.commit()
+            logger.info(f"Gene symbol {gene_symbol} added to target gene for score set {score_set.urn}.")
+
+        except Exception as e:
+            logger.error(f"Failed to generate gene mappings for score set {score_set.urn}: {str(e)}")
+            db.rollback()
+
+    logger.info("Done generating gene mappings.")
+
+
+if __name__ == "__main__":
+    generate_gene_mappings()

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -637,6 +637,20 @@ TEST_CDOT_TRANSCRIPT = {
 }
 
 
+TEST_MINIMAL_PRE_MAPPED_METADATA = {
+    "genomic": {"sequence_id": "ga4gh:SQ.em9khDCUYXrVWBfWr9r8fjBUrTjj1aig", "sequence_type": "dna"}
+}
+
+
+TEST_MINIMAL_POST_MAPPED_METADATA = {
+    "genomic": {
+        "sequence_id": "ga4gh:SQ.em9khDCUYXrVWBfWr9r8fjBUrTjj1aig",
+        "sequence_type": "dna",
+        "sequence_accessions": [VALID_ACCESSION],
+        "sequence_genes": [VALID_GENE],
+    }
+}
+
 TEST_VARIANT_MAPPING_SCAFFOLD = {
     "metadata": {},
     "computed_genomic_reference_sequence": {
@@ -653,6 +667,17 @@ TEST_VARIANT_MAPPING_SCAFFOLD = {
     "vrs_version": "2.0",
     "dcd_mapping_version": "pytest.0.0",
     "mapped_date_utc": datetime.isoformat(datetime.now()),
+}
+
+
+TEST_MINIMAL_MAPPED_VARIANT = {
+    "pre_mapped": {},
+    "post_mapped": {},
+    "modification_date": datetime.isoformat(datetime.now()),
+    "mapped_date": datetime.isoformat(datetime.now()),
+    "current": True,
+    "vrs_version": "2.0",
+    "mapping_api_version": "pytest.0.0",
 }
 
 

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -11,9 +11,13 @@ from mavedb.lib.score_sets import columns_for_dataset, create_variants, create_v
 from mavedb.lib.validation.dataframe import validate_and_standardize_dataframe_pair
 from mavedb.models.contributor import Contributor
 from mavedb.models.enums.processing_state import ProcessingState
+from mavedb.models.enums.mapping_state import MappingState
+from mavedb.models.mapped_variant import MappedVariant
 from mavedb.models.score_set import ScoreSet as ScoreSetDbModel
 from mavedb.models.license import License
+from mavedb.models.target_gene import TargetGene
 from mavedb.models.user import User
+from mavedb.models.variant import Variant
 from mavedb.view_models.collection import Collection
 from mavedb.view_models.experiment import Experiment, ExperimentCreate
 from mavedb.view_models.score_set import ScoreSet, ScoreSetCreate
@@ -23,7 +27,10 @@ from tests.helpers.constants import (
     TEST_COLLECTION,
     TEST_MINIMAL_ACC_SCORESET,
     TEST_MINIMAL_EXPERIMENT,
+    TEST_MINIMAL_PRE_MAPPED_METADATA,
+    TEST_MINIMAL_POST_MAPPED_METADATA,
     TEST_MINIMAL_SEQ_SCORESET,
+    TEST_MINIMAL_MAPPED_VARIANT,
 )
 
 
@@ -183,6 +190,25 @@ def mock_worker_variant_insertion(client, db, data_provider, score_set, scores_c
     db.commit()
 
     return client.get(f"/api/v1/score-sets/{score_set['urn']}").json()
+
+
+def create_mapped_variants_for_score_set(db, score_set_urn):
+    score_set = db.scalar(select(ScoreSetDbModel).where(ScoreSetDbModel.urn == score_set_urn))
+    targets = db.scalars(select(TargetGene).where(TargetGene.score_set_id == score_set.id))
+    variants = db.scalars(select(Variant).where(Variant.score_set_id == score_set.id)).all()
+
+    for variant in variants:
+        mv = MappedVariant(**TEST_MINIMAL_MAPPED_VARIANT, variant_id=variant.id)
+        db.add(mv)
+
+    for target in targets:
+        target.pre_mapped_metadata = TEST_MINIMAL_PRE_MAPPED_METADATA
+        target.post_mapped_metadata = TEST_MINIMAL_POST_MAPPED_METADATA
+        db.add(target)
+
+    score_set.mapping_state = MappingState.complete
+    db.commit()
+    return
 
 
 def create_seq_score_set_with_variants(

--- a/tests/routers/conftest.py
+++ b/tests/routers/conftest.py
@@ -28,6 +28,7 @@ from tests.helpers.util import (
     create_acc_score_set_with_variants,
     create_experiment,
     create_seq_score_set_with_variants,
+    create_mapped_variants_for_score_set,
     publish_score_set,
 )
 
@@ -76,6 +77,7 @@ def setup_seq_scoreset(setup_router_db, session, data_provider, client, data_fil
     score_set = create_seq_score_set_with_variants(
         client, session, data_provider, experiment["urn"], data_files / "scores.csv"
     )
+    create_mapped_variants_for_score_set(session, score_set["urn"])
     publish_score_set(client, score_set["urn"])
 
 

--- a/tests/routers/test_statistics.py
+++ b/tests/routers/test_statistics.py
@@ -12,6 +12,7 @@ from tests.helpers.constants import (
     TEST_MINIMAL_ACC_SCORESET,
     TEST_MINIMAL_SEQ_SCORESET,
     TEST_PUBMED_IDENTIFIER,
+    VALID_GENE,
 )
 from tests.helpers.util import (
     create_acc_score_set_with_variants,
@@ -236,6 +237,20 @@ def test_target_gene_empty_field(client):
     """Test target gene statistic response for an empty field."""
     response = client.get("/api/v1/statistics/target/gene/")
     assert response.status_code == 404
+
+
+####################################################################################################
+# Test mapped target gene statistics
+####################################################################################################
+
+
+def test_mapped_target_gene_counts(client, setup_router_db, setup_seq_scoreset):
+    """Test mapped target gene counts endpoint for published score sets."""
+    response = client.get("/api/v1/statistics/target/mapped/gene")
+    assert response.status_code == 200
+    assert isinstance(response.json(), dict)
+    assert len(response.json().keys()) == 1
+    assert response.json()[VALID_GENE] == 1
 
 
 ####################################################################################################
@@ -473,7 +488,7 @@ def test_mapped_variant_counts_groups(client, group_value, setup_router_db, setu
 
     for key, value in response.json().items():
         assert isinstance(key, str)
-        assert isinstance(value, int)
+        assert value == 3
 
 
 @pytest.mark.parametrize("group_value", ["month", "year", None])
@@ -499,7 +514,7 @@ def test_mapped_variant_counts_current(client, current_value, setup_router_db, s
 
     for key, value in response.json().items():
         assert isinstance(key, str)
-        assert isinstance(value, int)
+        assert value == 3
 
 
 @pytest.mark.parametrize("current_value", [True, False])


### PR DESCRIPTION
This change adds additional statistics router endpoints:
- `/api/v1/statistics/score-set/count?group`: Count of published score sets in MaveDB, possibly grouped by month or year.
- - `/api/v1/statistics/experiment/count?group`: Count of published experiments in MaveDB, possibly grouped by month or year.
- `/api/v1/statistics/target/mapped/gene`: Counts of gene symbols to which we have mapped targets. Included in this change is a script which populates this information for historically mapped targets.
- `/api/v1/statistics/variant/count?group`: The count of variant objects in MaveDB, possibly grouped by month or year.
- `/api/v1/statistics/mapped-variant/count?group&onlyCurrent`: The count of mapped variant objects in MaveDB, possibly grouped by month or year. An additional option `onlyCurrent` controls whether to only count current mapped variants.

In addition to the new routers above, this change refactors existing routes to clarify their logic. A prior version of this router used overly complex shared functions and enum fields that shared more code at the cost of overcomplicating simple stats routes. Here, we live with slightly more code duplication rather than complex functions that are tricky to edit and maintain.

Tests for the new routes have been added as well, in addition to a new test utility that adds mapped variants to the test database. 