### PR TITLE
VRS Digest Endpoint

### DIFF
--- a/alembic/versions/aa3933cf0cb3_add_ix_for_mapped_variant_pre_post_id.py
+++ b/alembic/versions/aa3933cf0cb3_add_ix_for_mapped_variant_pre_post_id.py
@@ -1,0 +1,31 @@
+"""add ix for mapped variant pre/post id
+
+Revision ID: aa3933cf0cb3
+Revises: f69b4049bc3b
+Create Date: 2025-06-02 11:42:34.479411
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "aa3933cf0cb3"
+down_revision = "f69b4049bc3b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_mapped_variants_pre_mapped_id", "mapped_variants", [sa.text("(pre_mapped->>'id')")], unique=False
+    )
+    op.create_index(
+        "ix_mapped_variants_post_mapped_id", "mapped_variants", [sa.text("(post_mapped->>'id')")], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index("ix_mapped_variants_pre_mapped_id", table_name="mapped_variants")
+    op.drop_index("ix_mapped_variants_post_mapped_id", table_name="mapped_variants")

--- a/mypy_stubs/ga4gh/core/identifiers.pyi
+++ b/mypy_stubs/ga4gh/core/identifiers.pyi
@@ -1,4 +1,7 @@
 from enum import Enum
+from re import Pattern
+
+GA4GH_IR_REGEXP: Pattern[str]
 
 class PrevVrsVersion(str, Enum):
     V1_3 = "1.3"

--- a/src/mavedb/models/mapped_variant.py
+++ b/src/mavedb/models/mapped_variant.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String
+from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String, Index, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, relationship
 
@@ -36,4 +36,9 @@ class MappedVariant(Base):
         "ClinicalControl",
         secondary=mapped_variants_clinical_controls_association_table,
         back_populates="mapped_variants",
+    )
+
+    __table_args__ = (
+        Index("ix_mapped_variants_pre_mapped_id", text("(pre_mapped->>'id')")),
+        Index("ix_mapped_variants_post_mapped_id", text("(post_mapped->>'id')")),
     )

--- a/src/mavedb/routers/mapped_variant.py
+++ b/src/mavedb/routers/mapped_variant.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, Path
 from fastapi.exceptions import HTTPException
-from ga4gh.core import GA4GH_IR_REGEXP
+from ga4gh.core.identifiers import GA4GH_IR_REGEXP
 from ga4gh.va_spec.base.core import ExperimentalVariantFunctionalImpactStudyResult, Statement
 from ga4gh.va_spec.acmg_2015 import VariantPathogenicityFunctionalImpactEvidenceLine
 from sqlalchemy import or_, select

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -17,7 +17,8 @@ TEST_MEDRXIV_IDENTIFIER = "2021.06.22.21259265"
 TEST_CROSSREF_IDENTIFIER = "10.1371/2021.06.22.21259265"
 TEST_ORCID_ID = "1111-1111-1111-1111"
 
-TEST_GA4GH_IDENTIFIER = "ga4gh:SQ.test"
+# "^ga4gh:([^.]+)\.([0-9A-Za-z_\-]{32})$"
+TEST_GA4GH_IDENTIFIER = "ga4gh:SQ.TestTestTestTestTestTestTestTest"
 # ^[0-9A-Za-z_\-]{32}$
 TEST_GA4GH_DIGEST = "ga4ghtest_ga4ghtest_ga4ghtest_dg"
 # ^SQ.[0-9A-Za-z_\-]{32}$


### PR DESCRIPTION
Closes #422.

Given the usefulness of GA4GH VRS Identifiers matching all variants which are given
with respect to the same transcript, it seems prudent to offer an endpoint which allows users to select mapped variant objects by this identifier. A filter for current variants is provided, and users must submit a valid GA4GH identifier string. Only variants in score sets a user has read access to will be exposed.

This change also adds an index on the identifier field of our pre and post mapped metadata to support faster fetches of these mapped variant objects.