### PR TITLE
API endpoint for score set variant scores with mapped coordinates

### DIFF
--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -619,26 +619,12 @@ def variant_to_csv_row(
         elif column_key == "post_mapped_hgvs_g":
             hgvs_str = get_hgvs_from_mapped_variant(mapping.post_mapped) if mapping and mapping.post_mapped else None
             if hgvs_str is not None and is_hgvs_g(hgvs_str):
-                # parsed_variant = hgvs_parser.parse(hgvs_str)
-                # if parsed_variant is None:
-                #     raise ValueError(f"Invalid HGVS notation in post-mapped variant: {hgvs_str}")
-                # elif parsed_variant.type == "g":
-                #     value = hgvs_str
-                # else:
-                #     value = ""
                 value = hgvs_str
             else:
                 value = ""
         elif column_key == "post_mapped_hgvs_p":
             hgvs_str = get_hgvs_from_mapped_variant(mapping.post_mapped) if mapping and mapping.post_mapped else None
             if hgvs_str is not None and is_hgvs_p(hgvs_str):
-                # parsed_variant = hgvs_parser.parse(hgvs_str)
-                # if parsed_variant is None:
-                #     raise ValueError(f"Invalid HGVS notation in post-mapped variant: {hgvs_str}")
-                # elif parsed_variant.type == "p":
-                #     value = hgvs_str
-                # else:
-                #     value = ""
                 value = hgvs_str
             else:
                 value = ""

--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -5,10 +5,11 @@ import re
 from operator import attrgetter
 from typing import Any, BinaryIO, Iterable, Optional, TYPE_CHECKING, Sequence, Literal
 
+from mavedb.models.mapped_variant import MappedVariant
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_index_equal
-from sqlalchemy import Integer, cast, func, or_, select
+from sqlalchemy import Integer, and_, cast, func, or_, select
 from sqlalchemy.orm import Session, aliased, contains_eager, joinedload, selectinload
 
 from mavedb.lib.exceptions import ValidationError
@@ -17,6 +18,7 @@ from mavedb.lib.mave.constants import (
     HGVS_NT_COLUMN,
     HGVS_PRO_COLUMN,
     HGVS_SPLICE_COLUMN,
+    REQUIRED_SCORE_COLUMN,
     VARIANT_COUNT_DATA,
     VARIANT_SCORE_DATA,
 )
@@ -56,6 +58,9 @@ if TYPE_CHECKING:
 VariantData = dict[str, Optional[dict[str, dict]]]
 
 logger = logging.getLogger(__name__)
+
+HGVS_G_REGEX = re.compile(r"(^|:)g\.")
+HGVS_P_REGEX = re.compile(r"(^|:)p\.")
 
 
 class HGVSColumns:
@@ -402,26 +407,90 @@ def get_score_set_variants_as_csv(
     start: Optional[int] = None,
     limit: Optional[int] = None,
     drop_na_columns: Optional[bool] = None,
+    include_custom_columns: bool = True,
+    include_post_mapped_hgvs: bool = False,
 ) -> str:
+    """
+    Get the variant data from a score set as a CSV string.
+
+    Parameters
+    __________
+    db : Session
+        The database session to use.
+    score_set : ScoreSet
+        The score set to get the variants from.
+    data_type : {'scores', 'counts'}
+        The type of data to get. Either 'scores' or 'counts'.
+    start : int, optional
+        The index to start from. If None, starts from the beginning.
+    limit : int, optional
+        The maximum number of variants to return. If None, returns all variants.
+    drop_na_columns : bool, optional
+        Whether to drop columns that contain only NA values. Defaults to False.
+    include_custom_columns : bool, optional
+        Whether to include custom columns defined in the score set. Defaults to True.
+    include_post_mapped_hgvs : bool, optional
+        Whether to include post-mapped HGVS notations in the output. Defaults to False. If True, the output will include
+        columns for both post-mapped HGVS genomic (g.) and protein (p.) notations.
+
+    Returns
+    _______
+    str
+        The CSV string containing the variant data.
+    """
     assert type(score_set.dataset_columns) is dict
-    dataset_cols = "score_columns" if data_type == "scores" else "count_columns"
+    custom_columns_set = "score_columns" if data_type == "scores" else "count_columns"
     type_column = "score_data" if data_type == "scores" else "count_data"
 
-    count_columns = [str(x) for x in list(score_set.dataset_columns.get(dataset_cols, []))]
-    columns = ["accession", "hgvs_nt", "hgvs_splice", "hgvs_pro"] + count_columns
+    columns = ["accession", "hgvs_nt", "hgvs_splice", "hgvs_pro"]
+    if include_post_mapped_hgvs:
+        columns.append("post_mapped_hgvs_g")
+        columns.append("post_mapped_hgvs_p")
 
-    variants_query = (
-        select(Variant)
-        .where(Variant.score_set_id == score_set.id)
-        .order_by(cast(func.split_part(Variant.urn, "#", 2), Integer))
-    )
-    if start:
-        variants_query = variants_query.offset(start)
-    if limit:
-        variants_query = variants_query.limit(limit)
-    variants = db.scalars(variants_query).all()
+    if include_custom_columns:
+        custom_columns = [str(x) for x in list(score_set.dataset_columns.get(custom_columns_set, []))]
+        columns += custom_columns
+    elif data_type == "scores":
+        columns.append(REQUIRED_SCORE_COLUMN)
 
-    rows_data = variants_to_csv_rows(variants, columns=columns, dtype=type_column)  # type: ignore
+    variants: Sequence[Variant] = []
+    mappings: Optional[list[Optional[MappedVariant]]] = None
+
+    if include_post_mapped_hgvs:
+        variants_and_mappings_query = (
+            select(Variant, MappedVariant)
+            .join(
+                MappedVariant,
+                and_(Variant.id == MappedVariant.variant_id, MappedVariant.current.is_(True)),
+                isouter=True,
+            )
+            .where(Variant.score_set_id == score_set.id)
+            .order_by(cast(func.split_part(Variant.urn, "#", 2), Integer))
+        )
+        if start:
+            variants_and_mappings_query = variants_and_mappings_query.offset(start)
+        if limit:
+            variants_and_mappings_query = variants_and_mappings_query.limit(limit)
+        variants_and_mappings = db.execute(variants_and_mappings_query).all()
+
+        variants = []
+        mappings = []
+        for variant, mapping in variants_and_mappings:
+            variants.append(variant)
+            mappings.append(mapping)
+    else:
+        variants_query = (
+            select(Variant)
+            .where(Variant.score_set_id == score_set.id)
+            .order_by(cast(func.split_part(Variant.urn, "#", 2), Integer))
+        )
+        if start:
+            variants_query = variants_query.offset(start)
+        if limit:
+            variants_query = variants_query.limit(limit)
+        variants = db.scalars(variants_query).all()
+
+    rows_data = variants_to_csv_rows(variants, columns=columns, dtype=type_column, mappings=mappings)  # type: ignore
     if drop_na_columns:
         rows_data, columns = drop_na_columns_from_csv_file_rows(rows_data, columns)
 
@@ -462,7 +531,63 @@ def is_null(value):
     return null_values_re.fullmatch(value) or not value
 
 
-def variant_to_csv_row(variant: Variant, columns: list[str], dtype: str, na_rep="NA") -> dict[str, Any]:
+def hgvs_from_vrs_allele(allele: dict) -> str:
+    """
+    Extract the HGVS notation from the VRS allele.
+    """
+    try:
+        # VRS 2.X
+        return allele["expressions"][0]["value"]
+    except KeyError:
+        raise ValueError("VRS 1.X format not supported.")
+        # VRS 1.X. We don't want to allow this.
+        # return allele["variation"]["expressions"][0]["value"]
+
+
+def get_hgvs_from_mapped_variant(post_mapped_vrs: Any) -> Optional[str]:
+    if post_mapped_vrs["type"] == "Haplotype":  # type: ignore
+        variations_hgvs = [hgvs_from_vrs_allele(allele) for allele in post_mapped_vrs["members"]]
+    elif post_mapped_vrs["type"] == "CisPhasedBlock":  # type: ignore
+        variations_hgvs = [hgvs_from_vrs_allele(allele) for allele in post_mapped_vrs["members"]]
+    elif post_mapped_vrs["type"] == "Allele":  # type: ignore
+        variations_hgvs = [hgvs_from_vrs_allele(post_mapped_vrs)]
+    else:
+        return None
+
+    if len(variations_hgvs) == 0:
+        return None
+        # raise ValueError(f"No variations found in variant {variant_urn}.")
+    if len(variations_hgvs) > 1:
+        return None
+        # raise ValueError(f"Multiple variations found in variant {variant_urn}.")
+
+    return variations_hgvs[0]
+
+
+# TODO (https://github.com/VariantEffect/mavedb-api/issues/440) Temporarily, we are using these functions to distinguish
+# genomic and protein HGVS strings produced by the mapper. Using hgvs.parser.Parser is too slow, and we won't need to do
+# this once the mapper extracts separate g., c., and p. post-mapped HGVS strings.
+def is_hgvs_g(hgvs: str) -> bool:
+    """
+    Check if the given HGVS string is a genomic HGVS (g.) string.
+    """
+    return bool(HGVS_G_REGEX.search(hgvs))
+
+
+def is_hgvs_p(hgvs: str) -> bool:
+    """
+    Check if the given HGVS string is a protein HGVS (p.) string.
+    """
+    return bool(HGVS_P_REGEX.search(hgvs))
+
+
+def variant_to_csv_row(
+    variant: Variant,
+    columns: list[str],
+    dtype: str,
+    mapping: Optional[MappedVariant] = None,
+    na_rep="NA",
+) -> dict[str, Any]:
     """
     Format a variant into a containing the keys specified in `columns`.
 
@@ -491,6 +616,32 @@ def variant_to_csv_row(variant: Variant, columns: list[str], dtype: str, na_rep=
             value = str(variant.hgvs_splice)
         elif column_key == "accession":
             value = str(variant.urn)
+        elif column_key == "post_mapped_hgvs_g":
+            hgvs_str = get_hgvs_from_mapped_variant(mapping.post_mapped) if mapping and mapping.post_mapped else None
+            if hgvs_str is not None and is_hgvs_g(hgvs_str):
+                # parsed_variant = hgvs_parser.parse(hgvs_str)
+                # if parsed_variant is None:
+                #     raise ValueError(f"Invalid HGVS notation in post-mapped variant: {hgvs_str}")
+                # elif parsed_variant.type == "g":
+                #     value = hgvs_str
+                # else:
+                #     value = ""
+                value = hgvs_str
+            else:
+                value = ""
+        elif column_key == "post_mapped_hgvs_p":
+            hgvs_str = get_hgvs_from_mapped_variant(mapping.post_mapped) if mapping and mapping.post_mapped else None
+            if hgvs_str is not None and is_hgvs_p(hgvs_str):
+                # parsed_variant = hgvs_parser.parse(hgvs_str)
+                # if parsed_variant is None:
+                #     raise ValueError(f"Invalid HGVS notation in post-mapped variant: {hgvs_str}")
+                # elif parsed_variant.type == "p":
+                #     value = hgvs_str
+                # else:
+                #     value = ""
+                value = hgvs_str
+            else:
+                value = ""
         else:
             parent = variant.data.get(dtype) if variant.data else None
             value = str(parent.get(column_key)) if parent else na_rep
@@ -502,7 +653,11 @@ def variant_to_csv_row(variant: Variant, columns: list[str], dtype: str, na_rep=
 
 
 def variants_to_csv_rows(
-    variants: Sequence[Variant], columns: list[str], dtype: str, na_rep="NA"
+    variants: Sequence[Variant],
+    columns: list[str],
+    dtype: str,
+    mappings: Optional[Sequence[Optional[MappedVariant]]] = None,
+    na_rep="NA",
 ) -> Iterable[dict[str, Any]]:
     """
     Format each variant into a dictionary row containing the keys specified in `columns`.
@@ -522,7 +677,12 @@ def variants_to_csv_rows(
     -------
     list[dict[str, Any]]
     """
-    return map(lambda v: variant_to_csv_row(v, columns, dtype, na_rep), variants)
+    if mappings is not None:
+        return map(
+            lambda pair: variant_to_csv_row(pair[0], columns, dtype, mapping=pair[1], na_rep=na_rep),
+            zip(variants, mappings),
+        )
+    return map(lambda v: variant_to_csv_row(v, columns, dtype, na_rep=na_rep), variants)
 
 
 def find_meta_analyses_for_score_sets(db: Session, urns: list[str]) -> list[ScoreSet]:

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -1095,10 +1095,7 @@ TEST_MINIMAL_MAPPED_VARIANT = {
 TEST_POST_MAPPED_VRS_WITH_HGVS_G_EXPRESSION = {
     "id": "ga4gh:VA.fRW7u-kBQnAKitu1PoDMLvlECWZTHCos",
     "type": "Allele",
-    "state": {
-        "type": "LiteralSequenceExpression",
-        "sequence": "G"
-    },
+    "state": {"type": "LiteralSequenceExpression", "sequence": "G"},
     "digest": "fRW7u-kBQnAKitu1PoDMLvlECWZTHCos",
     "location": {
         "id": "ga4gh:SL.99b3WBaSSmaSTs6YmJfIhl1ZDCV07VZY",
@@ -1109,27 +1106,17 @@ TEST_POST_MAPPED_VRS_WITH_HGVS_G_EXPRESSION = {
         "sequenceReference": {
             "type": "SequenceReference",
             "label": "NC_000018.10",
-            "refgetAccession": "SQ.vWwFhJ5lQDMhh-czg06YtlWqu0lvFAZV"
-        }
+            "refgetAccession": "SQ.vWwFhJ5lQDMhh-czg06YtlWqu0lvFAZV",
+        },
     },
-    "extensions": [{
-        "name": "vrs_ref_allele_seq",
-        "type": "Extension",
-        "value": "C"
-    }],
-    "expressions": [{
-        "value": "NC_000018.10:g.23536836C>G",
-        "syntax": "hgvs.g"
-    }]
+    "extensions": [{"name": "vrs_ref_allele_seq", "type": "Extension", "value": "C"}],
+    "expressions": [{"value": "NC_000018.10:g.23536836C>G", "syntax": "hgvs.g"}],
 }
 
 TEST_POST_MAPPED_VRS_WITH_HGVS_P_EXPRESSION = {
     "id": "ga4gh:VA.zkOAzZK5qG0D0mkJUfXlK1aS075OGSjh",
     "type": "Allele",
-    "state": {
-        "type": "LiteralSequenceExpression",
-        "sequence": "R"
-    },
+    "state": {"type": "LiteralSequenceExpression", "sequence": "R"},
     "digest": "zkOAzZK5qG0D0mkJUfXlK1aS075OGSjh",
     "location": {
         "id": "ga4gh:SL.uUyRpJbrPttRThL7A2zeWAnTcb_7f1R2",
@@ -1137,20 +1124,10 @@ TEST_POST_MAPPED_VRS_WITH_HGVS_P_EXPRESSION = {
         "type": "SequenceLocation",
         "start": 115,
         "digest": "uUyRpJbrPttRThL7A2zeWAnTcb_7f1R2",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.StlJo3M4b8cS253ufe9nPpWqQHBDOSPs"
-        }
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.StlJo3M4b8cS253ufe9nPpWqQHBDOSPs"},
     },
-    "extensions": [{
-        "name": "vrs_ref_allele_seq",
-        "type": "Extension",
-        "value": "Q"
-    }],
-    "expressions": [{
-        "value": "NP_002746.1:p.Gln116Arg",
-        "syntax": "hgvs.p"
-    }]
+    "extensions": [{"name": "vrs_ref_allele_seq", "type": "Extension", "value": "Q"}],
+    "expressions": [{"value": "NP_002746.1:p.Gln116Arg", "syntax": "hgvs.p"}],
 }
 
 TEST_MAPPED_VARIANT_WITH_HGVS_G_EXPRESSION = {

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -987,6 +987,15 @@ TEST_MINIMAL_POST_MAPPED_METADATA = {
     }
 }
 
+TEST_POST_MAPPED_METADATA_WITH_EXPRESSION = {
+    "genomic": {
+        "sequence_id": "ga4gh:SQ.em9khDCUYXrVWBfWr9r8fjBUrTjj1aig",
+        "sequence_type": "dna",
+        "sequence_accessions": [VALID_NT_ACCESSION],
+        "sequence_genes": [VALID_GENE],
+    }
+}
+
 TEST_SEQ_SCORESET_VARIANT_MAPPING_SCAFFOLD = {
     "metadata": {},
     "reference_sequences": {
@@ -1083,6 +1092,86 @@ TEST_MINIMAL_MAPPED_VARIANT = {
     "mapping_api_version": "pytest.0.0",
 }
 
+TEST_POST_MAPPED_VRS_WITH_HGVS_G_EXPRESSION = {
+    "id": "ga4gh:VA.fRW7u-kBQnAKitu1PoDMLvlECWZTHCos",
+    "type": "Allele",
+    "state": {
+        "type": "LiteralSequenceExpression",
+        "sequence": "G"
+    },
+    "digest": "fRW7u-kBQnAKitu1PoDMLvlECWZTHCos",
+    "location": {
+        "id": "ga4gh:SL.99b3WBaSSmaSTs6YmJfIhl1ZDCV07VZY",
+        "end": 23536836,
+        "type": "SequenceLocation",
+        "start": 23536835,
+        "digest": "99b3WBaSSmaSTs6YmJfIhl1ZDCV07VZY",
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "label": "NC_000018.10",
+            "refgetAccession": "SQ.vWwFhJ5lQDMhh-czg06YtlWqu0lvFAZV"
+        }
+    },
+    "extensions": [{
+        "name": "vrs_ref_allele_seq",
+        "type": "Extension",
+        "value": "C"
+    }],
+    "expressions": [{
+        "value": "NC_000018.10:g.23536836C>G",
+        "syntax": "hgvs.g"
+    }]
+}
+
+TEST_POST_MAPPED_VRS_WITH_HGVS_P_EXPRESSION = {
+    "id": "ga4gh:VA.zkOAzZK5qG0D0mkJUfXlK1aS075OGSjh",
+    "type": "Allele",
+    "state": {
+        "type": "LiteralSequenceExpression",
+        "sequence": "R"
+    },
+    "digest": "zkOAzZK5qG0D0mkJUfXlK1aS075OGSjh",
+    "location": {
+        "id": "ga4gh:SL.uUyRpJbrPttRThL7A2zeWAnTcb_7f1R2",
+        "end": 116,
+        "type": "SequenceLocation",
+        "start": 115,
+        "digest": "uUyRpJbrPttRThL7A2zeWAnTcb_7f1R2",
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.StlJo3M4b8cS253ufe9nPpWqQHBDOSPs"
+        }
+    },
+    "extensions": [{
+        "name": "vrs_ref_allele_seq",
+        "type": "Extension",
+        "value": "Q"
+    }],
+    "expressions": [{
+        "value": "NP_002746.1:p.Gln116Arg",
+        "syntax": "hgvs.p"
+    }]
+}
+
+TEST_MAPPED_VARIANT_WITH_HGVS_G_EXPRESSION = {
+    "pre_mapped": {},
+    "post_mapped": TEST_POST_MAPPED_VRS_WITH_HGVS_G_EXPRESSION,
+    "modification_date": datetime.isoformat(datetime.now()),
+    "mapped_date": datetime.isoformat(datetime.now()),
+    "current": True,
+    "vrs_version": "2.0",
+    "mapping_api_version": "pytest.0.0",
+}
+
+TEST_MAPPED_VARIANT_WITH_HGVS_P_EXPRESSION = {
+    "pre_mapped": {},
+    "post_mapped": TEST_POST_MAPPED_VRS_WITH_HGVS_P_EXPRESSION,
+    "modification_date": datetime.isoformat(datetime.now()),
+    "mapped_date": datetime.isoformat(datetime.now()),
+    "current": True,
+    "vrs_version": "2.0",
+    "mapping_api_version": "pytest.0.0",
+}
 
 TEST_WT_SCORE = 1.0
 

--- a/tests/helpers/util/variant.py
+++ b/tests/helpers/util/variant.py
@@ -17,7 +17,6 @@ from mavedb.models.target_gene import TargetGene
 from mavedb.models.variant import Variant
 
 from tests.helpers.constants import (
-    TEST_MINIMAL_MAPPED_VARIANT,
     TEST_MINIMAL_PRE_MAPPED_METADATA,
     TEST_MINIMAL_POST_MAPPED_METADATA,
 )
@@ -84,13 +83,13 @@ def mock_worker_variant_insertion(
     return client.get(f"api/v1/score-sets/{score_set['urn']}").json()
 
 
-def create_mapped_variants_for_score_set(db, score_set_urn):
+def create_mapped_variants_for_score_set(db, score_set_urn, mapped_variant: dict[str, any]):
     score_set = db.scalar(select(ScoreSet).where(ScoreSet.urn == score_set_urn))
     targets = db.scalars(select(TargetGene).where(TargetGene.score_set_id == score_set.id))
     variants = db.scalars(select(Variant).where(Variant.score_set_id == score_set.id)).all()
 
     for variant in variants:
-        mv = MappedVariant(**TEST_MINIMAL_MAPPED_VARIANT, variant_id=variant.id)
+        mv = MappedVariant(**mapped_variant, variant_id=variant.id)
         db.add(mv)
 
     for target in targets:

--- a/tests/routers/test_score_set.py
+++ b/tests/routers/test_score_set.py
@@ -2351,8 +2351,19 @@ def test_upload_a_non_utf8_file(session, client, setup_router_db, data_files):
 # Score set download files
 ########################################################################################################################
 
-@pytest.mark.parametrize("mapped_variant,has_hgvs_g,has_hgvs_p", [(None, False, False), (TEST_MAPPED_VARIANT_WITH_HGVS_G_EXPRESSION, True, False), (TEST_MAPPED_VARIANT_WITH_HGVS_P_EXPRESSION, False, True)], ids=["without_post_mapped_vrs", "with_post_mapped_hgvs_g", "with_post_mapped_hgvs_p"])
-def test_download_variants_data_file(session, data_provider, client, setup_router_db, data_files, mapped_variant, has_hgvs_g, has_hgvs_p):
+
+@pytest.mark.parametrize(
+    "mapped_variant,has_hgvs_g,has_hgvs_p",
+    [
+        (None, False, False),
+        (TEST_MAPPED_VARIANT_WITH_HGVS_G_EXPRESSION, True, False),
+        (TEST_MAPPED_VARIANT_WITH_HGVS_P_EXPRESSION, False, True),
+    ],
+    ids=["without_post_mapped_vrs", "with_post_mapped_hgvs_g", "with_post_mapped_hgvs_p"],
+)
+def test_download_variants_data_file(
+    session, data_provider, client, setup_router_db, data_files, mapped_variant, has_hgvs_g, has_hgvs_p
+):
     experiment = create_experiment(client)
     score_set = create_seq_score_set(client, experiment["urn"])
     score_set = mock_worker_variant_insertion(client, session, data_provider, score_set, data_files / "scores.csv")
@@ -2370,14 +2381,16 @@ def test_download_variants_data_file(session, data_provider, client, setup_route
     download_scores_csv = download_scores_csv_response.text
 
     reader = csv.DictReader(StringIO(download_scores_csv))
-    assert sorted(reader.fieldnames) == sorted([
-        "accession",
-        "hgvs_nt",
-        "hgvs_pro",
-        "post_mapped_hgvs_g",
-        "post_mapped_hgvs_p",
-        "score",
-    ])
+    assert sorted(reader.fieldnames) == sorted(
+        [
+            "accession",
+            "hgvs_nt",
+            "hgvs_pro",
+            "post_mapped_hgvs_g",
+            "post_mapped_hgvs_p",
+            "score",
+        ]
+    )
     rows = list(reader)
     for row in rows:
         if has_hgvs_g:

--- a/tests/routers/test_statistics.py
+++ b/tests/routers/test_statistics.py
@@ -12,6 +12,7 @@ from mavedb.models.published_variant import PublishedVariantsMV
 
 from tests.helpers.constants import (
     TEST_BIORXIV_IDENTIFIER,
+    TEST_MINIMAL_MAPPED_VARIANT,
     TEST_NT_CDOT_TRANSCRIPT,
     TEST_KEYWORDS,
     TEST_MEDRXIV_IDENTIFIER,
@@ -64,7 +65,7 @@ def setup_seq_scoreset(setup_router_db, session, data_provider, client, data_fil
     unpublished_score_set = mock_worker_variant_insertion(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
-    create_mapped_variants_for_score_set(session, unpublished_score_set["urn"])
+    create_mapped_variants_for_score_set(session, unpublished_score_set["urn"], TEST_MINIMAL_MAPPED_VARIANT)
 
     with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
         publish_score_set(client, unpublished_score_set["urn"])


### PR DESCRIPTION
To support the web interface's ability to display mapped coordinates to clinical users, this update exposes a new API endpoint that serves variant scores with mapped HGVS strings.