### PR TITLE
Submit to ClinGen Allele Registry Before Linked Data Hub (#454)

### DIFF
--- a/settings/.env.template
+++ b/settings/.env.template
@@ -65,7 +65,11 @@ DCD_MAPPING_URL=http://dcd-mapping:8000
 # Environment variables for ClinGen
 ####################################################################################################
 
-GENBOREE_ACCOUNT_NAME=
-GENBOREE_ACCOUNT_PASSWORD=
-CLIN_GEN_TENANT=
-CLIN_GEN_SUBMISSION_ENABLED=
+CLIN_GEN_SUBMISSION_ENABLED=false
+# ClinGen Genboree Authentication settings
+GENBOREE_ACCOUNT_NAME=testuser
+GENBOREE_ACCOUNT_PASSWORD=testpassword
+# ClinGen Linked Data Hub (LDH) settings
+CLIN_GEN_TENANT=dev-clingen
+# ClinGen Allele Registry (CAR) settings
+CAR_SUBMISSION_ENDPOINT=http://reg.test.genome.network

--- a/src/mavedb/lib/clingen/constants.py
+++ b/src/mavedb/lib/clingen/constants.py
@@ -7,6 +7,8 @@ GENBOREE_ACCOUNT_PASSWORD = os.getenv("GENBOREE_ACCOUNT_PASSWORD")
 
 CLIN_GEN_TENANT = os.getenv("CLIN_GEN_TENANT")
 
+CAR_SUBMISSION_ENDPOINT = os.getenv("CAR_SUBMISSION_ENDPOINT")
+
 LDH_SUBMISSION_TYPE = "cg-ldh-ld-submission"
 LDH_ENTITY_NAME = "MaveDBMapping"
 LDH_ENTITY_ENDPOINT = "maveDb"  # for some reason, not the same :/

--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -25,6 +25,7 @@ from mavedb.lib.mave.constants import (
 from mavedb.lib.mave.utils import is_csv_null
 from mavedb.lib.validation.constants.general import null_values_list
 from mavedb.lib.validation.utilities import is_null as validate_is_null
+from mavedb.lib.variants import get_hgvs_from_post_mapped, is_hgvs_g, is_hgvs_p
 from mavedb.models.contributor import Contributor
 from mavedb.models.controlled_keyword import ControlledKeyword
 from mavedb.models.doi_identifier import DoiIdentifier
@@ -58,9 +59,6 @@ if TYPE_CHECKING:
 VariantData = dict[str, Optional[dict[str, dict]]]
 
 logger = logging.getLogger(__name__)
-
-HGVS_G_REGEX = re.compile(r"(^|:)g\.")
-HGVS_P_REGEX = re.compile(r"(^|:)p\.")
 
 
 class HGVSColumns:
@@ -531,56 +529,6 @@ def is_null(value):
     return null_values_re.fullmatch(value) or not value
 
 
-def hgvs_from_vrs_allele(allele: dict) -> str:
-    """
-    Extract the HGVS notation from the VRS allele.
-    """
-    try:
-        # VRS 2.X
-        return allele["expressions"][0]["value"]
-    except KeyError:
-        raise ValueError("VRS 1.X format not supported.")
-        # VRS 1.X. We don't want to allow this.
-        # return allele["variation"]["expressions"][0]["value"]
-
-
-def get_hgvs_from_mapped_variant(post_mapped_vrs: Any) -> Optional[str]:
-    if post_mapped_vrs["type"] == "Haplotype":  # type: ignore
-        variations_hgvs = [hgvs_from_vrs_allele(allele) for allele in post_mapped_vrs["members"]]
-    elif post_mapped_vrs["type"] == "CisPhasedBlock":  # type: ignore
-        variations_hgvs = [hgvs_from_vrs_allele(allele) for allele in post_mapped_vrs["members"]]
-    elif post_mapped_vrs["type"] == "Allele":  # type: ignore
-        variations_hgvs = [hgvs_from_vrs_allele(post_mapped_vrs)]
-    else:
-        return None
-
-    if len(variations_hgvs) == 0:
-        return None
-        # raise ValueError(f"No variations found in variant {variant_urn}.")
-    if len(variations_hgvs) > 1:
-        return None
-        # raise ValueError(f"Multiple variations found in variant {variant_urn}.")
-
-    return variations_hgvs[0]
-
-
-# TODO (https://github.com/VariantEffect/mavedb-api/issues/440) Temporarily, we are using these functions to distinguish
-# genomic and protein HGVS strings produced by the mapper. Using hgvs.parser.Parser is too slow, and we won't need to do
-# this once the mapper extracts separate g., c., and p. post-mapped HGVS strings.
-def is_hgvs_g(hgvs: str) -> bool:
-    """
-    Check if the given HGVS string is a genomic HGVS (g.) string.
-    """
-    return bool(HGVS_G_REGEX.search(hgvs))
-
-
-def is_hgvs_p(hgvs: str) -> bool:
-    """
-    Check if the given HGVS string is a protein HGVS (p.) string.
-    """
-    return bool(HGVS_P_REGEX.search(hgvs))
-
-
 def variant_to_csv_row(
     variant: Variant,
     columns: list[str],
@@ -617,13 +565,13 @@ def variant_to_csv_row(
         elif column_key == "accession":
             value = str(variant.urn)
         elif column_key == "post_mapped_hgvs_g":
-            hgvs_str = get_hgvs_from_mapped_variant(mapping.post_mapped) if mapping and mapping.post_mapped else None
+            hgvs_str = get_hgvs_from_post_mapped(mapping.post_mapped) if mapping and mapping.post_mapped else None
             if hgvs_str is not None and is_hgvs_g(hgvs_str):
                 value = hgvs_str
             else:
                 value = ""
         elif column_key == "post_mapped_hgvs_p":
-            hgvs_str = get_hgvs_from_mapped_variant(mapping.post_mapped) if mapping and mapping.post_mapped else None
+            hgvs_str = get_hgvs_from_post_mapped(mapping.post_mapped) if mapping and mapping.post_mapped else None
             if hgvs_str is not None and is_hgvs_p(hgvs_str):
                 value = hgvs_str
             else:

--- a/src/mavedb/lib/types/clingen.py
+++ b/src/mavedb/lib/types/clingen.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypedDict, Literal
+from typing import Any, Optional, TypedDict, Literal
 from typing_extensions import NotRequired
 
 
@@ -80,3 +80,75 @@ class LdhSubmissionContent(TypedDict):
 class LdhSubmission(TypedDict):
     event: LdhEvent
     content: LdhSubmissionContent
+
+
+## Allele Registry Response Types
+
+# For many of these objects, typing has been omitted for brevity. Details about field contents are
+# available in the ClinGen Allele Registry documentation: https://reg.clinicalgenome.org/doc/AlleleRegistry_1.01.xx_api_v1.pdf
+# and should be added as needed.
+
+
+class ClinGenExternalRecord(TypedDict):
+    dbSnp: NotRequired[list[dict[str, Any]]]
+    ClinVarAlleles: NotRequired[list[dict[str, Any]]]
+    ClinVarVariations: NotRequired[list[dict[str, Any]]]
+    MyVariantInfo_hg38: NotRequired[list[dict[str, Any]]]
+    MyVariantInfo_hg19: NotRequired[list[dict[str, Any]]]
+    ExAC: NotRequired[list[dict[str, Any]]]
+    gnomAD: NotRequired[list[dict[str, Any]]]
+    COSMIC: NotRequired[list[dict[str, Any]]]
+
+
+class ClinGenAlleleDefinition(TypedDict):
+    hgvs: list[str]
+    referenceSequence: str
+    gene: NotRequired[str]
+    geneSymbol: NotRequired[str]
+    geneId: NotRequired[int]
+    coordinates: NotRequired[dict[str, Any]]
+    referenceGeneome: NotRequired[Literal["GRCh37", "GRCh38", "NCBI36"]]
+    chromosome: NotRequired[
+        Literal[
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "X",
+            "Y",
+            "MT",
+        ]
+    ]
+
+
+ClinGenAllele = TypedDict(
+    "ClinGenAllele",
+    {
+        "@id": str,
+        "type": Literal["nucleotide", "amino-acid"],
+        "activeUris": list[str],
+        "externalRecords": NotRequired[list[ClinGenExternalRecord]],
+        "externalSources": NotRequired[dict[str, Any]],
+        "genomicAlleles": NotRequired[list[ClinGenAlleleDefinition]],
+        "transcriptAlleles": NotRequired[list[ClinGenAlleleDefinition]],
+        "aminoAcidAlleles": NotRequired[list[ClinGenAlleleDefinition]],
+    },
+)

--- a/src/mavedb/lib/variants.py
+++ b/src/mavedb/lib/variants.py
@@ -1,4 +1,9 @@
-from mavedb.models.mapped_variant import MappedVariant
+import re
+from typing import Any, Optional
+
+
+HGVS_G_REGEX = re.compile(r"(^|:)g\.")
+HGVS_P_REGEX = re.compile(r"(^|:)p\.")
 
 
 def hgvs_from_vrs_allele(allele: dict) -> str:
@@ -9,24 +14,52 @@ def hgvs_from_vrs_allele(allele: dict) -> str:
         # VRS 2.X
         return allele["expressions"][0]["value"]
     except KeyError:
-        # VRS 1.X
-        return allele["variation"]["expressions"][0]["value"]
+        if "variation" in allele:
+            raise ValueError("VRS 1.X format not supported.")
+            # VRS 1.X. We don't want to allow this.
+            # return allele["variation"]["expressions"][0]["value"]
+        else:
+            raise KeyError("Invalid VRS allele structure. Expected 'expressions'.")
 
 
-def hgvs_from_mapped_variant(mapped_variant: MappedVariant) -> list[str]:
-    """
-    Extract the HGVS notation from the post_mapped field of the MappedVariant object.
-    """
-    post_mapped_object: dict = mapped_variant.post_mapped  # type: ignore
+def get_hgvs_from_post_mapped(post_mapped_vrs: Optional[Any]) -> Optional[str]:
+    if not post_mapped_vrs:
+        return None
 
-    if not post_mapped_object:
-        return []
-
-    if post_mapped_object["type"] == "Haplotype":  # type: ignore
-        return [hgvs_from_vrs_allele(allele) for allele in post_mapped_object["members"]]
-    elif post_mapped_object["type"] == "CisPhasedBlock":  # type: ignore
-        return [hgvs_from_vrs_allele(allele) for allele in post_mapped_object["members"]]
-    elif post_mapped_object["type"] == "Allele":  # type: ignore
-        return [hgvs_from_vrs_allele(post_mapped_object)]
+    if post_mapped_vrs["type"] == "Haplotype":  # type: ignore
+        variations_hgvs = [hgvs_from_vrs_allele(allele) for allele in post_mapped_vrs["members"]]
+    elif post_mapped_vrs["type"] == "CisPhasedBlock":  # type: ignore
+        variations_hgvs = [hgvs_from_vrs_allele(allele) for allele in post_mapped_vrs["members"]]
+    elif post_mapped_vrs["type"] == "Allele":  # type: ignore
+        variations_hgvs = [hgvs_from_vrs_allele(post_mapped_vrs)]
     else:
-        raise ValueError(f"Unsupported post_mapped type: {post_mapped_object['type']}")
+        return None
+
+    if len(variations_hgvs) == 0:
+        return None
+        # raise ValueError(f"No variations found in variant {variant_urn}.")
+
+    # TODO (https://github.com/VariantEffect/mavedb-api/issues/468) In a future version, we will be able to generate
+    # a combined HGVS string for haplotypes and cis phased blocks directly from mapper output.
+    if len(variations_hgvs) > 1:
+        return None
+        # raise ValueError(f"Multiple variations found in variant {variant_urn}.")
+
+    return variations_hgvs[0]
+
+
+# TODO (https://github.com/VariantEffect/mavedb-api/issues/440) Temporarily, we are using these functions to distinguish
+# genomic and protein HGVS strings produced by the mapper. Using hgvs.parser.Parser is too slow, and we won't need to do
+# this once the mapper extracts separate g., c., and p. post-mapped HGVS strings.
+def is_hgvs_g(hgvs: str) -> bool:
+    """
+    Check if the given HGVS string is a genomic HGVS (g.) string.
+    """
+    return bool(HGVS_G_REGEX.search(hgvs))
+
+
+def is_hgvs_p(hgvs: str) -> bool:
+    """
+    Check if the given HGVS string is a protein HGVS (p.) string.
+    """
+    return bool(HGVS_P_REGEX.search(hgvs))

--- a/src/mavedb/scripts/clingen_car_submission.py
+++ b/src/mavedb/scripts/clingen_car_submission.py
@@ -1,0 +1,133 @@
+import click
+import logging
+from typing import Sequence
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from mavedb.models.score_set import ScoreSet
+from mavedb.models.variant import Variant
+from mavedb.models.mapped_variant import MappedVariant
+from mavedb.scripts.environment import with_database_session
+from mavedb.lib.clingen.services import ClinGenAlleleRegistryService, get_allele_registry_associations
+from mavedb.lib.clingen.constants import CAR_SUBMISSION_ENDPOINT
+from mavedb.lib.variants import get_hgvs_from_post_mapped
+
+logger = logging.getLogger(__name__)
+
+
+def submit_urns_to_car(db: Session, urns: Sequence[str], debug: bool) -> list[str]:
+    if not CAR_SUBMISSION_ENDPOINT:
+        logger.error("`CAR_SUBMISSION_ENDPOINT` is not set. Please check your configuration.")
+        return []
+
+    car_service = ClinGenAlleleRegistryService(url=CAR_SUBMISSION_ENDPOINT)
+    submitted_entities = []
+
+    if debug:
+        logger.debug("Debug mode enabled. Submitting only one request to ClinGen CAR.")
+        urns = urns[:1]
+
+    for idx, urn in enumerate(urns):
+        logger.info(f"Processing URN: {urn}. (Scoreset {idx + 1}/{len(urns)})")
+        try:
+            score_set = db.scalars(select(ScoreSet).where(ScoreSet.urn == urn)).one_or_none()
+            if not score_set:
+                logger.warning(f"No score set found for URN: {urn}")
+                continue
+
+            logger.info(f"Submitting mapped variants to CAR service for score set with URN: {urn}")
+            variant_objects = db.execute(
+                select(Variant, MappedVariant)
+                .join(MappedVariant, MappedVariant.variant_id == Variant.id)
+                .join(ScoreSet)
+                .where(ScoreSet.urn == urn)
+                .where(MappedVariant.post_mapped.is_not(None))
+                .where(MappedVariant.current.is_(True))
+            ).all()
+
+            if not variant_objects:
+                logger.warning(f"No mapped variants found for score set with URN: {urn}")
+                continue
+
+            if debug:
+                logger.debug(f"Debug mode enabled. Submitting only one variant to ClinGen CAR for URN: {urn}")
+                variant_objects = variant_objects[:1]
+
+            logger.debug(f"Preparing {len(variant_objects)} mapped variants for CAR submission")
+            hgvs_to_mapped_variant: dict[str, list[int]] = {}
+            for variant, mapped_variant in variant_objects:
+                hgvs = get_hgvs_from_post_mapped(mapped_variant.post_mapped)
+                if hgvs and hgvs not in hgvs_to_mapped_variant:
+                    hgvs_to_mapped_variant[hgvs] = [mapped_variant.id]
+                elif hgvs and hgvs in hgvs_to_mapped_variant:
+                    hgvs_to_mapped_variant[hgvs].append(mapped_variant.id)
+                else:
+                    logger.warning(f"No HGVS string found for mapped variant {variant.urn}")
+
+            if not hgvs_to_mapped_variant:
+                logger.warning(f"No HGVS strings to submit for URN: {urn}")
+                continue
+
+            logger.info(f"Submitting {len(hgvs_to_mapped_variant)} HGVS strings to CAR service for URN: {urn}")
+            response = car_service.dispatch_submissions(list(hgvs_to_mapped_variant.keys()))
+
+            if not response:
+                logger.error(f"CAR submission failed for URN: {urn}")
+            else:
+                logger.info(f"Successfully submitted to CAR for URN: {urn}")
+                # Associate CAIDs with mapped variants
+                associations = get_allele_registry_associations(list(hgvs_to_mapped_variant.keys()), response)
+                for hgvs, caid in associations.items():
+                    mapped_variant_ids = hgvs_to_mapped_variant.get(hgvs, [])
+                    for mv_id in mapped_variant_ids:
+                        mapped_variant = db.scalar(select(MappedVariant).where(MappedVariant.id == mv_id))
+                        if not mapped_variant:
+                            logger.warning(f"Mapped variant with ID {mv_id} not found for HGVS {hgvs}.")
+                            continue
+
+                        mapped_variant.clingen_allele_id = caid
+                        db.add(mapped_variant)
+
+                submitted_entities.extend([variant.urn for variant, _ in variant_objects])
+
+        except Exception as e:
+            logger.error(f"Error processing URN {urn}", exc_info=e)
+
+    return submitted_entities
+
+
+@click.command()
+@with_database_session
+@click.argument("urns", nargs=-1)
+@click.option("--all", help="Submit variants for every score set in MaveDB.", is_flag=True)
+@click.option("--suppress-output", help="Suppress final print output to the console.", is_flag=True)
+@click.option("--debug", help="Enable debug mode. This will send only one request at most to ClinGen CAR", is_flag=True)
+def submit_car_urns_command(
+    db: Session,
+    urns: Sequence[str],
+    all: bool,
+    suppress_output: bool,
+    debug: bool,
+) -> None:
+    """
+    Submit data to ClinGen Allele Registry for mapped variant CAID generation for the given URNs.
+    """
+    if urns and all:
+        logger.error("Cannot provide both URNs and --all option.")
+        return
+
+    if all:
+        urns = db.scalars(select(ScoreSet.urn)).all()  # type: ignore
+
+    if not urns:
+        logger.error("No URNs provided. Please provide at least one URN.")
+        return
+
+    submitted_variant_urns = submit_urns_to_car(db, urns, debug)
+
+    if not suppress_output:
+        print(", ".join(submitted_variant_urns))
+
+
+if __name__ == "__main__":
+    submit_car_urns_command()

--- a/src/mavedb/scripts/clingen_ldh_submission.py
+++ b/src/mavedb/scripts/clingen_ldh_submission.py
@@ -10,7 +10,7 @@ from mavedb.models.score_set import ScoreSet
 from mavedb.models.variant import Variant
 from mavedb.models.mapped_variant import MappedVariant
 from mavedb.scripts.environment import with_database_session
-from mavedb.lib.clingen.linked_data_hub import ClinGenLdhService
+from mavedb.lib.clingen.services import ClinGenLdhService
 from mavedb.lib.clingen.constants import DEFAULT_LDH_SUBMISSION_BATCH_SIZE, LDH_SUBMISSION_ENDPOINT
 from mavedb.lib.clingen.content_constructors import construct_ldh_submission
 from mavedb.lib.variants import hgvs_from_mapped_variant
@@ -20,7 +20,10 @@ logger = logging.getLogger(__name__)
 intronic_variant_with_reference_regex = re.compile(r":c\..*[+-]")
 variant_with_reference_regex = re.compile(r":")
 
-def submit_urns_to_clingen(db: Session, urns: Sequence[str], unlinked_only: bool, prefer_unmapped_hgvs: bool, debug: bool) -> list[str]:
+
+def submit_urns_to_clingen(
+    db: Session, urns: Sequence[str], unlinked_only: bool, prefer_unmapped_hgvs: bool, debug: bool
+) -> list[str]:
     ldh_service = ClinGenLdhService(url=LDH_SUBMISSION_ENDPOINT)
     ldh_service.authenticate()
 
@@ -40,7 +43,11 @@ def submit_urns_to_clingen(db: Session, urns: Sequence[str], unlinked_only: bool
                 continue
 
             logger.info(f"Submitting mapped variants to LDH service for score set with URN: {urn}")
-            mapped_variant_join_clause = and_(MappedVariant.variant_id == Variant.id, MappedVariant.post_mapped.is_not(None), MappedVariant.current.is_(True))
+            mapped_variant_join_clause = and_(
+                MappedVariant.variant_id == Variant.id,
+                MappedVariant.post_mapped.is_not(None),
+                MappedVariant.current.is_(True),
+            )
             variant_objects = db.execute(
                 select(Variant, MappedVariant)
                 .join(MappedVariant, mapped_variant_join_clause, isouter=True)
@@ -74,28 +81,42 @@ def submit_urns_to_clingen(db: Session, urns: Sequence[str], unlinked_only: bool
                         if variation:
                             logger.info(f"Using hgvs_pro for unmapped non-intronic variant {variant.urn}: {variation}")
                     else:
-                        logger.warning(f"No variation found for unmapped variant {variant.urn} (nt: {variant.hgvs_nt}, aa: {variant.hgvs_pro}, splice: {variant.hgvs_splice}).")
+                        logger.warning(
+                            f"No variation found for unmapped variant {variant.urn} (nt: {variant.hgvs_nt}, aa: {variant.hgvs_pro}, splice: {variant.hgvs_splice})."
+                        )
                         continue
                 else:
                     if unlinked_only and mapped_variant.clingen_allele_id:
                         continue
                     # If the script was run with the --prefer-unmapped-hgvs flag, use the hgvs_nt string rather than the
                     # mapped variant, as long as the variant is accession-based.
-                    if prefer_unmapped_hgvs and variant.hgvs_nt is not None and variant_with_reference_regex.search(variant.hgvs_nt):
+                    if (
+                        prefer_unmapped_hgvs
+                        and variant.hgvs_nt is not None
+                        and variant_with_reference_regex.search(variant.hgvs_nt)
+                    ):
                         variation = [variant.hgvs_nt]
                         if variation:
                             logger.info(f"Using hgvs_nt for mapped variant {variant.urn}: {variation}")
-                    elif prefer_unmapped_hgvs and variant.hgvs_pro is not None and variant_with_reference_regex.search(variant.hgvs_pro):
+                    elif (
+                        prefer_unmapped_hgvs
+                        and variant.hgvs_pro is not None
+                        and variant_with_reference_regex.search(variant.hgvs_pro)
+                    ):
                         variation = [variant.hgvs_pro]
                         if variation:
-                            logger.info(f"Using hgvs_pro for mapped variant {variant.urn}: {variation}")                # continue  # TEMPORARY. Only submit unmapped variants.
+                            logger.info(
+                                f"Using hgvs_pro for mapped variant {variant.urn}: {variation}"
+                            )  # continue  # TEMPORARY. Only submit unmapped variants.
                     else:
                         variation = hgvs_from_mapped_variant(mapped_variant)
                         if variation:
                             logger.info(f"Using mapped variant for {variant.urn}: {variation}")
 
                 if not variation:
-                    logger.warning(f"No variation found for mapped variant {variant.urn} (nt: {variant.hgvs_nt}, aa: {variant.hgvs_pro}, splice: {variant.hgvs_splice}).")
+                    logger.warning(
+                        f"No variation found for mapped variant {variant.urn} (nt: {variant.hgvs_nt}, aa: {variant.hgvs_pro}, splice: {variant.hgvs_splice})."
+                    )
                     continue
 
                 for allele in variation:
@@ -129,12 +150,28 @@ def submit_urns_to_clingen(db: Session, urns: Sequence[str], unlinked_only: bool
 @with_database_session
 @click.argument("urns", nargs=-1)
 @click.option("--all", help="Submit variants for every score set in MaveDB.", is_flag=True)
-@click.option("--unlinked", default=False, help="Only submit variants that have not already been linked to ClinGen alleles.", is_flag=True)
-@click.option("--prefer-unmapped-hgvs", default=False, help="If the unmapped HGVS string is accession-based, use it in the submission instead of the mapped variant.", is_flag=True)
+@click.option(
+    "--unlinked",
+    default=False,
+    help="Only submit variants that have not already been linked to ClinGen alleles.",
+    is_flag=True,
+)
+@click.option(
+    "--prefer-unmapped-hgvs",
+    default=False,
+    help="If the unmapped HGVS string is accession-based, use it in the submission instead of the mapped variant.",
+    is_flag=True,
+)
 @click.option("--suppress-output", help="Suppress final print output to the console.", is_flag=True)
 @click.option("--debug", help="Enable debug mode. This will send only one request at most to ClinGen", is_flag=True)
 def submit_clingen_urns_command(
-    db: Session, urns: Sequence[str], all: bool, unlinked: bool, prefer_unmapped_hgvs: bool, suppress_output: bool, debug: bool
+    db: Session,
+    urns: Sequence[str],
+    all: bool,
+    unlinked: bool,
+    prefer_unmapped_hgvs: bool,
+    suppress_output: bool,
+    debug: bool,
 ) -> None:
     """
     Submit data to ClinGen for mapped variant allele ID generation for the given URNs.

--- a/src/mavedb/scripts/link_clingen_variants.py
+++ b/src/mavedb/scripts/link_clingen_variants.py
@@ -5,7 +5,7 @@ from typing import Sequence
 from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
-from mavedb.lib.clingen.linked_data_hub import get_clingen_variation, clingen_allele_id_from_ldh_variation
+from mavedb.lib.clingen.services import get_clingen_variation, clingen_allele_id_from_ldh_variation
 from mavedb.models.score_set import ScoreSet
 from mavedb.models.variant import Variant
 from mavedb.models.mapped_variant import MappedVariant
@@ -51,7 +51,9 @@ def link_clingen_variants(db: Session, urns: Sequence[str], score_sets: bool, un
             failed_urns.append(urn)
             continue
 
-        mapped_variant = db.scalar(select(MappedVariant).join(Variant).where(and_(Variant.urn == urn, MappedVariant.current.is_(True))))
+        mapped_variant = db.scalar(
+            select(MappedVariant).join(Variant).where(and_(Variant.urn == urn, MappedVariant.current.is_(True)))
+        )
 
         if not mapped_variant:
             logger.warning(f"No mapped variant found for URN {urn}.")

--- a/src/mavedb/worker/jobs.py
+++ b/src/mavedb/worker/jobs.py
@@ -16,16 +16,19 @@ from sqlalchemy.orm import Session
 from mavedb.data_providers.services import vrs_mapper
 from mavedb.db.view import refresh_all_mat_views
 from mavedb.lib.clingen.constants import (
+    CAR_SUBMISSION_ENDPOINT,
     DEFAULT_LDH_SUBMISSION_BATCH_SIZE,
     LDH_SUBMISSION_ENDPOINT,
     LINKED_DATA_RETRY_THRESHOLD,
     CLIN_GEN_SUBMISSION_ENABLED,
 )
 from mavedb.lib.clingen.content_constructors import construct_ldh_submission
-from mavedb.lib.clingen.linked_data_hub import (
+from mavedb.lib.clingen.services import (
+    ClinGenAlleleRegistryService,
     ClinGenLdhService,
     get_clingen_variation,
     clingen_allele_id_from_ldh_variation,
+    get_allele_registry_associations,
 )
 from mavedb.lib.exceptions import (
     MappingEnqueueError,
@@ -552,7 +555,7 @@ async def map_variants_for_score_set(
     try:
         if CLIN_GEN_SUBMISSION_ENABLED:
             new_job = await redis.enqueue_job(
-                "submit_score_set_mappings_to_ldh",
+                "submit_score_set_mappings_to_car",
                 correlation_id,
                 score_set.id,
             )
@@ -560,21 +563,21 @@ async def map_variants_for_score_set(
             if new_job:
                 new_job_id = new_job.job_id
 
-                logging_context["submit_clingen_variants_job_id"] = new_job_id
+                logging_context["submit_clingen_car_variants_job_id"] = new_job_id
                 logger.info(msg="Queued a new ClinGen submission job.", extra=logging_context)
 
             else:
                 raise SubmissionEnqueueError()
         else:
             logger.warning(
-                msg="ClinGen submission is disabled, skipped submission of mapped variants to LDH.",
+                msg="ClinGen submission is disabled, skipped submission of mapped variants to CAR and LDH.",
                 extra=logging_context,
             )
 
     except Exception as e:
         send_slack_error(e)
         send_slack_message(
-            f"Could not submit mappings to LDH for score set {score_set.urn}. Mappings for this score set should be submitted manually."
+            f"Could not submit mappings to CAR and/or LDH mappings for score set {score_set.urn}. Mappings for this score set should be submitted manually."
         )
         logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
         logger.error(
@@ -743,6 +746,161 @@ async def refresh_published_variants_view(ctx: dict, correlation_id: str):
 ####################################################################################################
 #  ClinGen resource creation / linkage
 ####################################################################################################
+
+
+async def submit_score_set_mappings_to_car(ctx: dict, correlation_id: str, score_set_id: int):
+    logging_context = {}
+    score_set = None
+    text = "Could not submit mappings to ClinGen Allele Registry for score set %s. Mappings for this score set should be submitted manually."
+    try:
+        db: Session = ctx["db"]
+        redis: ArqRedis = ctx["redis"]
+        score_set = db.scalars(select(ScoreSet).where(ScoreSet.id == score_set_id)).one()
+
+        logging_context = setup_job_state(ctx, None, score_set.urn, correlation_id)
+        logger.info(msg="Started CAR mapped resource submission", extra=logging_context)
+
+        submission_urn = score_set.urn
+        assert submission_urn, "A valid URN is needed to submit CAR objects for this score set."
+
+        logging_context["current_car_submission_resource"] = submission_urn
+        logger.debug(msg="Fetched score set metadata for CAR mapped resource submission.", extra=logging_context)
+
+    except Exception as e:
+        send_slack_error(e)
+        if score_set:
+            send_slack_message(text=text % score_set.urn)
+        else:
+            send_slack_message(text=text % score_set_id)
+
+        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
+        logger.error(
+            msg="CAR mapped resource submission encountered an unexpected error during setup. This job will not be retried.",
+            extra=logging_context,
+        )
+
+        return {"success": False, "retried": False, "enqueued_job": None}
+
+    try:
+        variant_post_mapped_objects = db.execute(
+            select(MappedVariant.id, MappedVariant.post_mapped)
+            .join(Variant)
+            .join(ScoreSet)
+            .where(ScoreSet.urn == score_set.urn)
+            .where(MappedVariant.post_mapped.is_not(None))
+            .where(MappedVariant.current.is_(True))
+        ).all()
+
+        if not variant_post_mapped_objects:
+            logger.warning(
+                msg="No current mapped variants with post mapped metadata were found for this score set. Skipping CAR submission.",
+                extra=logging_context,
+            )
+            return {"success": True, "retried": False, "enqueued_job": None}
+
+        variant_post_mapped_hgvs: dict[str, list[int]] = {}
+        for mapped_variant_id, post_mapped in variant_post_mapped_objects:
+            hgvs_for_post_mapped = get_hgvs_from_post_mapped(post_mapped)
+
+            if not hgvs_for_post_mapped:
+                logger.warning(
+                    msg=f"Could not construct a valid HGVS string for mapped variant {mapped_variant_id}. Skipping submission of this variant.",
+                    extra=logging_context,
+                )
+                continue
+
+            if hgvs_for_post_mapped in variant_post_mapped_hgvs:
+                variant_post_mapped_hgvs[hgvs_for_post_mapped].append(mapped_variant_id)
+            else:
+                variant_post_mapped_hgvs[hgvs_for_post_mapped] = [mapped_variant_id]
+
+    except Exception as e:
+        send_slack_error(e)
+        send_slack_message(text=text % score_set.urn)
+        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
+        logger.error(
+            msg="LDH mapped resource submission encountered an unexpected error while attempting to construct post mapped HGVS strings. This job will not be retried.",
+            extra=logging_context,
+        )
+
+        return {"success": False, "retried": False, "enqueued_job": None}
+
+    try:
+        if not CAR_SUBMISSION_ENDPOINT:
+            logger.warning(
+                msg="ClinGen Allele Registry submission is disabled (no submission endpoint), skipping submission of mapped variants to CAR.",
+                extra=logging_context,
+            )
+            return {"success": False, "retried": False, "enqueued_job": None}
+
+        car_service = ClinGenAlleleRegistryService(url=CAR_SUBMISSION_ENDPOINT)
+        registered_alleles = car_service.dispatch_submissions(list(variant_post_mapped_hgvs.keys()))
+    except Exception as e:
+        send_slack_error(e)
+        send_slack_message(text=text % score_set.urn)
+        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
+        logger.error(
+            msg="LDH mapped resource submission encountered an unexpected error while attempting to authenticate to the LDH. This job will not be retried.",
+            extra=logging_context,
+        )
+
+        return {"success": False, "retried": False, "enqueued_job": None}
+
+    try:
+        linked_alleles = get_allele_registry_associations(list(variant_post_mapped_hgvs.keys()), registered_alleles)
+        for hgvs_string, caid in linked_alleles.items():
+            mapped_variant_ids = variant_post_mapped_hgvs[hgvs_string]
+            mapped_variants = db.scalars(select(MappedVariant).where(MappedVariant.id.in_(mapped_variant_ids))).all()
+
+            for mapped_variant in mapped_variants:
+                mapped_variant.clingen_allele_id = caid
+                db.add(mapped_variant)
+
+        db.commit()
+
+    except Exception as e:
+        send_slack_error(e)
+        send_slack_message(text=text % score_set.urn)
+        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
+        logger.error(
+            msg="LDH mapped resource submission encountered an unexpected error while attempting to authenticate to the LDH. This job will not be retried.",
+            extra=logging_context,
+        )
+
+        return {"success": False, "retried": False, "enqueued_job": None}
+
+    new_job_id = None
+    try:
+        new_job = await redis.enqueue_job(
+            "submit_score_set_mappings_to_ldh",
+            correlation_id,
+            score_set.id,
+        )
+
+        if new_job:
+            new_job_id = new_job.job_id
+
+            logging_context["submit_clingen_ldh_variants_job_id"] = new_job_id
+            logger.info(msg="Queued a new ClinGen submission job.", extra=logging_context)
+
+        else:
+            raise SubmissionEnqueueError()
+
+    except Exception as e:
+        send_slack_error(e)
+        send_slack_message(
+            f"Could not submit mappings to LDH for score set {score_set.urn}. Mappings for this score set should be submitted manually."
+        )
+        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
+        logger.error(
+            msg="Mapped variant ClinGen submission encountered an unexpected error while attempting to enqueue a submission job. This job will not be retried.",
+            extra=logging_context,
+        )
+
+        return {"success": False, "retried": False, "enqueued_job": new_job_id}
+
+    ctx["state"][ctx["job_id"]] = logging_context.copy()
+    return {"success": True, "retried": False, "enqueued_job": new_job_id}
 
 
 async def submit_score_set_mappings_to_ldh(ctx: dict, correlation_id: str, score_set_id: int):

--- a/tests/conftest_optional.py
+++ b/tests/conftest_optional.py
@@ -22,6 +22,7 @@ from mavedb.worker.jobs import (
     link_clingen_variants,
     submit_score_set_mappings_to_ldh,
     variant_mapper_manager,
+    submit_score_set_mappings_to_car,
 )
 
 from tests.helpers.constants import ADMIN_USER, EXTRA_USER, TEST_USER
@@ -112,6 +113,7 @@ async def arq_worker(data_provider, session, arq_redis):
             variant_mapper_manager,
             submit_score_set_mappings_to_ldh,
             link_clingen_variants,
+            submit_score_set_mappings_to_car,
         ],
         redis_pool=arq_redis,
         burst=True,

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -1477,3 +1477,125 @@ TEST_CLINGEN_LDH_LINKING_RESPONSE_BAD_REQUEST = {
     "errName": "Bad Request",
     "errCat": "INVALID URL",
 }
+
+
+TEST_CLINGEN_ALLELE_OBJECT = {
+    "@context": "http://reg.genome.network/schema/allele.jsonld",
+    "@id": "http://reg.genome.network/allele/CA341478553",
+    "communityStandardTitle": ["NM_001408.3(CELSR2):c.1A>G (p.Met1Val)"],
+    "externalRecords": {
+        "MyVariantInfo_hg19": [
+            {"@id": "http://myvariant.info/v1/variant/chr1:g.109792702A>G?assembly=hg19", "id": "chr1:g.109792702A>G"}
+        ],
+        "MyVariantInfo_hg38": [
+            {"@id": "http://myvariant.info/v1/variant/chr1:g.109250080A>G?assembly=hg38", "id": "chr1:g.109250080A>G"}
+        ],
+        "gnomAD_4": [
+            {
+                "@id": "http://gnomad.broadinstitute.org/variant/1-109250080-A-G?dataset=gnomad_r4",
+                "id": "1-109250080-A-G",
+                "variant": "1:109250080 A / G",
+            }
+        ],
+    },
+    "genomicAlleles": [
+        {
+            "chromosome": "1",
+            "coordinates": [{"allele": "G", "end": 109250080, "referenceAllele": "A", "start": 109250079}],
+            "hgvs": ["NC_000001.11:g.109250080A>G", "CM000663.2:g.109250080A>G"],
+            "referenceGenome": "GRCh38",
+            "referenceSequence": "http://reg.genome.network/refseq/RS000049",
+        },
+        {
+            "chromosome": "1",
+            "coordinates": [{"allele": "G", "end": 109792702, "referenceAllele": "A", "start": 109792701}],
+            "hgvs": ["NC_000001.10:g.109792702A>G", "CM000663.1:g.109792702A>G"],
+            "referenceGenome": "GRCh37",
+            "referenceSequence": "http://reg.genome.network/refseq/RS000025",
+        },
+        {
+            "chromosome": "1",
+            "coordinates": [{"allele": "G", "end": 109594225, "referenceAllele": "A", "start": 109594224}],
+            "hgvs": ["NC_000001.9:g.109594225A>G"],
+            "referenceGenome": "NCBI36",
+            "referenceSequence": "http://reg.genome.network/refseq/RS000001",
+        },
+        {
+            "coordinates": [{"allele": "G", "end": 5376, "referenceAllele": "A", "start": 5375}],
+            "hgvs": ["NG_052669.1:g.5376A>G"],
+            "referenceSequence": "http://reg.genome.network/refseq/RS617150",
+        },
+    ],
+    "transcriptAlleles": [
+        {
+            "coordinates": [{"allele": "G", "end": 542, "referenceAllele": "A", "start": 541}],
+            "gene": "http://reg.genome.network/gene/GN003231",
+            "geneNCBI_id": 1952,
+            "geneSymbol": "CELSR2",
+            "hgvs": ["ENST00000271332.4:c.1A>G", TEST_HGVS_IDENTIFIER],
+            "proteinEffect": {"hgvs": "ENSP00000271332.3:p.Met1Val", "hgvsWellDefined": "ENSP00000271332.3:p.Met1Val"},
+            "referenceSequence": "http://reg.genome.network/refseq/RS743193",
+            "MANE": {
+                "maneVersion": "1.3",
+                "maneStatus": "MANE Select",
+                "nucleotide": {
+                    "Ensembl": {"hgvs": "ENST00000271332.4:c.1A>G"},
+                    "RefSeq": {"hgvs": "NM_001408.3:c.1A>G"},
+                },
+                "protein": {
+                    "Ensembl": {"hgvs": "ENSP00000271332.3:p.Met1Val"},
+                    "RefSeq": {"hgvs": "NP_001399.1:p.Met1Val"},
+                },
+            },
+        },
+        {
+            "coordinates": [{"allele": "G", "end": 62, "referenceAllele": "A", "start": 61}],
+            "gene": "http://reg.genome.network/gene/GN003231",
+            "geneNCBI_id": 1952,
+            "geneSymbol": "CELSR2",
+            "hgvs": ["ENST00000271332.3:c.1A>G"],
+            "proteinEffect": {"hgvs": "ENSP00000271332.3:p.Met1Val", "hgvsWellDefined": "ENSP00000271332.3:p.Met1Val"},
+            "referenceSequence": "http://reg.genome.network/refseq/RS252294",
+        },
+        {
+            "coordinates": [{"allele": "G", "end": 62, "referenceAllele": "A", "start": 61}],
+            "gene": "http://reg.genome.network/gene/GN003231",
+            "geneNCBI_id": 1952,
+            "geneSymbol": "CELSR2",
+            "hgvs": ["NM_001408.2:c.1A>G"],
+            "proteinEffect": {"hgvs": "NP_001399.1:p.Met1Val", "hgvsWellDefined": "NP_001399.1:p.Met1Val"},
+            "referenceSequence": "http://reg.genome.network/refseq/RS026793",
+        },
+        {
+            "coordinates": [{"allele": "G", "end": 366, "referenceAllele": "A", "start": 365}],
+            "gene": "http://reg.genome.network/gene/GN003231",
+            "geneNCBI_id": 1952,
+            "geneSymbol": "CELSR2",
+            "hgvs": ["XM_005270580.3:c.1A>G"],
+            "proteinEffect": {"hgvs": "XP_005270637.1:p.Met1Val", "hgvsWellDefined": "XP_005270637.1:p.Met1Val"},
+            "referenceSequence": "http://reg.genome.network/refseq/RS066576",
+        },
+        {
+            "coordinates": [{"allele": "G", "end": 542, "referenceAllele": "A", "start": 541}],
+            "gene": "http://reg.genome.network/gene/GN003231",
+            "geneNCBI_id": 1952,
+            "geneSymbol": "CELSR2",
+            "hgvs": ["NM_001408.3:c.1A>G"],
+            "proteinEffect": {"hgvs": "NP_001399.1:p.Met1Val", "hgvsWellDefined": "NP_001399.1:p.Met1Val"},
+            "referenceSequence": "http://reg.genome.network/refseq/RS664974",
+            "MANE": {
+                "maneVersion": "1.3",
+                "maneStatus": "MANE Select",
+                "nucleotide": {
+                    "Ensembl": {"hgvs": "ENST00000271332.4:c.1A>G"},
+                    "RefSeq": {"hgvs": "NM_001408.3:c.1A>G"},
+                },
+                "protein": {
+                    "Ensembl": {"hgvs": "ENSP00000271332.3:p.Met1Val"},
+                    "RefSeq": {"hgvs": "NP_001399.1:p.Met1Val"},
+                },
+            },
+        },
+    ],
+    "type": "nucleotide",
+}

--- a/tests/lib/clingen/test_linked_data_hub.py
+++ b/tests/lib/clingen/test_linked_data_hub.py
@@ -13,7 +13,7 @@ fastapi = pytest.importorskip("fastapi")
 
 from mavedb.lib.clingen.constants import LDH_MAVE_ACCESS_ENDPOINT, GENBOREE_ACCOUNT_NAME, GENBOREE_ACCOUNT_PASSWORD
 from mavedb.lib.utils import batched
-from mavedb.lib.clingen.linked_data_hub import (
+from mavedb.lib.clingen.services import (
     ClinGenLdhService,
     get_clingen_variation,
     clingen_allele_id_from_ldh_variation,

--- a/tests/lib/test_variants.py
+++ b/tests/lib/test_variants.py
@@ -1,8 +1,6 @@
 import pytest
-from unittest.mock import MagicMock
 
-from mavedb.lib.variants import hgvs_from_vrs_allele
-from mavedb.lib.variants import hgvs_from_mapped_variant
+from mavedb.lib.variants import hgvs_from_vrs_allele, get_hgvs_from_post_mapped, is_hgvs_g, is_hgvs_p
 
 from tests.helpers.constants import (
     TEST_HGVS_IDENTIFIER,
@@ -13,56 +11,82 @@ from tests.helpers.constants import (
 )
 
 
-@pytest.mark.parametrize("allele", [TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS1_X, TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X])
-def test_hgvs_from_vrs_allele(allele):
-    result = hgvs_from_vrs_allele(allele)
-    assert result == TEST_HGVS_IDENTIFIER
+def test_hgvs_from_vrs_allele_vrs_1():
+    with pytest.raises(ValueError):
+        hgvs_from_vrs_allele(TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS1_X)
+
+
+def test_hgvs_from_vrs_allele_vrs_2():
+    hgvs_string = hgvs_from_vrs_allele(TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X)
+    assert hgvs_string == TEST_HGVS_IDENTIFIER
 
 
 def test_hgvs_from_vrs_allele_invalid():
-    allele = {"invalid_key": "invalid_value"}
     with pytest.raises(KeyError):
-        hgvs_from_vrs_allele(allele)
+        hgvs_from_vrs_allele({"invalid_key": "invalid_value"})
 
 
-def test_hgvs_from_mapped_variant_haplotype():
-    mapped_variant = MagicMock()
-    mapped_variant.post_mapped = TEST_VALID_POST_MAPPED_VRS_HAPLOTYPE
-    result = hgvs_from_mapped_variant(mapped_variant)
-    assert result == [TEST_HGVS_IDENTIFIER, TEST_HGVS_IDENTIFIER]
-
-
-def test_hgvs_from_mapped_variant_cis_phased_block():
-    mapped_variant = MagicMock()
-    mapped_variant.post_mapped = TEST_VALID_POST_MAPPED_VRS_CIS_PHASED_BLOCK
-    result = hgvs_from_mapped_variant(mapped_variant)
-    assert result == [TEST_HGVS_IDENTIFIER, TEST_HGVS_IDENTIFIER]
-
-
-@pytest.mark.parametrize("allele", [TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS1_X, TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X])
-def test_hgvs_from_mapped_variant_single_allele(allele):
-    mapped_variant = MagicMock()
-    mapped_variant.post_mapped = allele
-    result = hgvs_from_mapped_variant(mapped_variant)
-    assert result == [TEST_HGVS_IDENTIFIER]
-
-
-def test_hgvs_from_mapped_variant_empty_post_mapped():
-    mapped_variant = MagicMock()
-    mapped_variant.post_mapped = None
-    result = hgvs_from_mapped_variant(mapped_variant)
-    assert result == []
-
-
-def test_hgvs_from_mapped_variant_invalid_type():
-    mapped_variant = MagicMock()
-    mapped_variant.post_mapped = {"type": "InvalidType"}
+def test_get_hgvs_from_post_mapped_haplotype():
     with pytest.raises(ValueError):
-        hgvs_from_mapped_variant(mapped_variant)
+        get_hgvs_from_post_mapped(TEST_VALID_POST_MAPPED_VRS_HAPLOTYPE)
 
 
-def test_hgvs_from_mapped_variant_invalid_structure():
-    mapped_variant = MagicMock()
-    mapped_variant.post_mapped = {"invalid_key": "InvalidType"}
+def test_get_hgvs_from_post_mapped_cis_phased_block():
+    result = get_hgvs_from_post_mapped(TEST_VALID_POST_MAPPED_VRS_CIS_PHASED_BLOCK)
+    assert result is None
+
+
+def test_get_hgvs_from_post_mapped_single_allele_vrs_1():
+    with pytest.raises(ValueError):
+        get_hgvs_from_post_mapped(TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS1_X)
+
+
+def test_get_hgvs_from_post_mapped_single_allele_vrs_2():
+    result = get_hgvs_from_post_mapped(TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X)
+    assert result == TEST_HGVS_IDENTIFIER
+
+
+def test_get_hgvs_from_post_mapped_empty_post_mapped():
+    result = get_hgvs_from_post_mapped(None)
+    assert result is None
+
+
+def test_get_hgvs_from_post_mapped_invalid_type():
+    result = get_hgvs_from_post_mapped({"type": "InvalidType"})
+    assert result is None
+
+
+def test_get_hgvs_from_post_mapped_invalid_structure():
     with pytest.raises(KeyError):
-        hgvs_from_mapped_variant(mapped_variant)
+        get_hgvs_from_post_mapped({"invalid_key": "InvalidType"})
+
+
+@pytest.mark.parametrize(
+    "hgvs,expected",
+    [
+        ("NC_000001.11:g.123456A>T", True),
+        ("chr1:g.123456A>T", True),
+        ("NM_000546.5:c.215C>G", False),
+        ("NP_000537.3:p.Arg72Pro", False),
+        ("g.123456A>T", True),
+        ("p.Arg72Pro", False),
+        ("", False),
+    ],
+)
+def test_is_hgvs_g(hgvs, expected):
+    assert is_hgvs_g(hgvs) == expected
+
+
+@pytest.mark.parametrize(
+    "hgvs,expected",
+    [
+        ("NP_000537.3:p.Arg72Pro", True),
+        ("p.Arg72Pro", True),
+        ("NC_000001.11:g.123456A>T", False),
+        ("chr1:g.123456A>T", False),
+        ("c.215C>G", False),
+        ("", False),
+    ],
+)
+def test_is_hgvs_p(hgvs, expected):
+    assert is_hgvs_p(hgvs) == expected

--- a/tests/worker/test_jobs.py
+++ b/tests/worker/test_jobs.py
@@ -18,7 +18,7 @@ fastapi = pytest.importorskip("fastapi")
 from mavedb.data_providers.services import VRSMap
 from mavedb.lib.mave.constants import HGVS_NT_COLUMN
 from mavedb.lib.score_sets import csv_data_to_df
-from mavedb.lib.clingen.linked_data_hub import ClinGenLdhService, clingen_allele_id_from_ldh_variation
+from mavedb.lib.clingen.services import ClinGenLdhService, clingen_allele_id_from_ldh_variation
 from mavedb.lib.validation.exceptions import ValidationError
 from mavedb.models.enums.mapping_state import MappingState
 from mavedb.models.enums.processing_state import ProcessingState

--- a/tests/worker/test_jobs.py
+++ b/tests/worker/test_jobs.py
@@ -18,7 +18,11 @@ fastapi = pytest.importorskip("fastapi")
 from mavedb.data_providers.services import VRSMap
 from mavedb.lib.mave.constants import HGVS_NT_COLUMN
 from mavedb.lib.score_sets import csv_data_to_df
-from mavedb.lib.clingen.services import ClinGenLdhService, clingen_allele_id_from_ldh_variation
+from mavedb.lib.clingen.services import (
+    ClinGenAlleleRegistryService,
+    ClinGenLdhService,
+    clingen_allele_id_from_ldh_variation,
+)
 from mavedb.lib.validation.exceptions import ValidationError
 from mavedb.models.enums.mapping_state import MappingState
 from mavedb.models.enums.processing_state import ProcessingState
@@ -36,11 +40,12 @@ from mavedb.worker.jobs import (
     variant_mapper_manager,
     submit_score_set_mappings_to_ldh,
     link_clingen_variants,
+    submit_score_set_mappings_to_car,
 )
-
 
 from tests.helpers.constants import (
     TEST_ACC_SCORESET_VARIANT_MAPPING_SCAFFOLD,
+    TEST_CLINGEN_ALLELE_OBJECT,
     TEST_CLINGEN_SUBMISSION_RESPONSE,
     TEST_CLINGEN_SUBMISSION_BAD_RESQUEST_RESPONSE,
     TEST_CLINGEN_SUBMISSION_UNAUTHORIZED_RESPONSE,
@@ -53,9 +58,7 @@ from tests.helpers.constants import (
     TEST_MULTI_TARGET_SCORESET_VARIANT_MAPPING_SCAFFOLD,
     TEST_SEQ_SCORESET_VARIANT_MAPPING_SCAFFOLD,
     VALID_NT_ACCESSION,
-    TEST_VALID_PRE_MAPPED_VRS_ALLELE_VRS1_X,
     TEST_VALID_PRE_MAPPED_VRS_ALLELE_VRS2_X,
-    TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS1_X,
     TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X,
 )
 from tests.helpers.util.exceptions import awaitable_exception
@@ -185,10 +188,8 @@ async def setup_mapping_output(
     variants = session.scalars(select(Variant).join(ScoreSetDbModel).where(ScoreSetDbModel.urn == score_set.urn)).all()
     for variant in variants:
         mapped_score = {
-            "pre_mapped": TEST_VALID_PRE_MAPPED_VRS_ALLELE_VRS1_X,
-            "pre_mapped_2_0": TEST_VALID_PRE_MAPPED_VRS_ALLELE_VRS2_X,
-            "post_mapped": TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS1_X,
-            "post_mapped_2_0": TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X,
+            "pre_mapped": TEST_VALID_PRE_MAPPED_VRS_ALLELE_VRS2_X,
+            "post_mapped": TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X,
             "mavedb_id": variant.urn,
         }
 
@@ -529,7 +530,10 @@ async def test_create_variants_for_score_set_enqueues_manager_and_successful_map
     async def dummy_mapping_job():
         return await setup_mapping_output(async_client, session, score_set, score_set_is_seq, score_set_is_multi_target)
 
-    async def dummy_submission_job():
+    async def dummy_car_submission_job():
+        return TEST_CLINGEN_ALLELE_OBJECT
+
+    async def dummy_ldh_submission_job():
         return [TEST_CLINGEN_SUBMISSION_RESPONSE, None]
 
     # Variants have not yet been created, so infer their URNs.
@@ -545,7 +549,12 @@ async def test_create_variants_for_score_set_enqueues_manager_and_successful_map
         patch.object(
             _UnixSelectorEventLoop,
             "run_in_executor",
-            side_effect=[dummy_mapping_job(), dummy_submission_job(), dummy_linking_job()],
+            side_effect=[
+                dummy_mapping_job(),
+                dummy_car_submission_job(),
+                dummy_ldh_submission_job(),
+                dummy_linking_job(),
+            ],
         ),
         patch.object(ClinGenLdhService, "_existing_jwt", return_value="test_jwt"),
         patch("mavedb.worker.jobs.MAPPING_BACKOFF_IN_SECONDS", 0),
@@ -1472,7 +1481,7 @@ async def test_mapping_manager_enqueues_mapping_process_with_successful_mapping(
     async def dummy_mapping_job():
         return await setup_mapping_output(async_client, session, score_set)
 
-    async def dummy_submission_job():
+    async def dummy_ldh_submission_job():
         return [TEST_CLINGEN_SUBMISSION_RESPONSE, None]
 
     async def dummy_linking_job():
@@ -1490,18 +1499,22 @@ async def test_mapping_manager_enqueues_mapping_process_with_successful_mapping(
         patch.object(
             _UnixSelectorEventLoop,
             "run_in_executor",
-            side_effect=[dummy_mapping_job(), dummy_submission_job(), dummy_linking_job()],
+            side_effect=[dummy_mapping_job(), dummy_ldh_submission_job(), dummy_linking_job()],
         ),
+        patch.object(ClinGenAlleleRegistryService, "dispatch_submissions", return_value=[TEST_CLINGEN_ALLELE_OBJECT]),
         patch.object(ClinGenLdhService, "_existing_jwt", return_value="test_jwt"),
         patch("mavedb.worker.jobs.MAPPING_BACKOFF_IN_SECONDS", 0),
         patch("mavedb.worker.jobs.LINKING_BACKOFF_IN_SECONDS", 0),
         patch("mavedb.worker.jobs.CLIN_GEN_SUBMISSION_ENABLED", True),
+        patch("mavedb.worker.jobs.CAR_SUBMISSION_ENDPOINT", "https://reg.test.genome.network/pytest"),
+        patch("mavedb.lib.clingen.services.GENBOREE_ACCOUNT_NAME", "testuser"),
+        patch("mavedb.lib.clingen.services.GENBOREE_ACCOUNT_PASSWORD", "testpassword"),
     ):
         await arq_worker.async_run()
         num_completed_jobs = await arq_worker.run_check()
 
     # We should have completed all jobs exactly once.
-    assert num_completed_jobs == 4
+    assert num_completed_jobs == 5
 
     score_set = session.scalars(select(ScoreSetDbModel).where(ScoreSetDbModel.urn == score_set.urn)).one()
     mapped_variants_for_score_set = session.scalars(
@@ -1578,7 +1591,7 @@ async def test_mapping_manager_enqueues_mapping_process_with_retried_mapping_suc
     async def dummy_mapping_job():
         return await setup_mapping_output(async_client, session, score_set)
 
-    async def dummy_submission_job():
+    async def dummy_ldh_submission_job():
         return [TEST_CLINGEN_SUBMISSION_RESPONSE, None]
 
     async def dummy_linking_job():
@@ -1596,18 +1609,22 @@ async def test_mapping_manager_enqueues_mapping_process_with_retried_mapping_suc
         patch.object(
             _UnixSelectorEventLoop,
             "run_in_executor",
-            side_effect=[failed_mapping_job(), dummy_mapping_job(), dummy_submission_job(), dummy_linking_job()],
+            side_effect=[failed_mapping_job(), dummy_mapping_job(), dummy_ldh_submission_job(), dummy_linking_job()],
         ),
         patch.object(ClinGenLdhService, "_existing_jwt", return_value="test_jwt"),
+        patch.object(ClinGenAlleleRegistryService, "dispatch_submissions", return_value=[TEST_CLINGEN_ALLELE_OBJECT]),
         patch("mavedb.worker.jobs.MAPPING_BACKOFF_IN_SECONDS", 0),
         patch("mavedb.worker.jobs.LINKING_BACKOFF_IN_SECONDS", 0),
         patch("mavedb.worker.jobs.CLIN_GEN_SUBMISSION_ENABLED", True),
+        patch("mavedb.worker.jobs.CAR_SUBMISSION_ENDPOINT", "https://reg.test.genome.network/pytest"),
+        patch("mavedb.lib.clingen.services.GENBOREE_ACCOUNT_NAME", "testuser"),
+        patch("mavedb.lib.clingen.services.GENBOREE_ACCOUNT_PASSWORD", "testpassword"),
     ):
         await arq_worker.async_run()
         num_completed_jobs = await arq_worker.run_check()
 
-    # We should have completed the mapping manager job twice, the mapping job twice, the submission job, and the linking job.
-    assert num_completed_jobs == 6
+    # We should have completed the mapping manager job twice, the mapping job twice, both ClinGen submission jobs, and the linking job.
+    assert num_completed_jobs == 7
 
     score_set = session.scalars(select(ScoreSetDbModel).where(ScoreSetDbModel.urn == score_set.urn)).one()
     mapped_variants_for_score_set = session.scalars(
@@ -1664,7 +1681,188 @@ async def test_mapping_manager_enqueues_mapping_process_with_unsuccessful_mappin
 
 
 ############################################################################################################################################
-# ClinGen Submission
+# ClinGen CAR Submission
+############################################################################################################################################
+
+
+@pytest.mark.asyncio
+async def test_submit_score_set_mappings_to_car_success(
+    setup_worker_db, standalone_worker_context, session, async_client, data_files, arq_worker, arq_redis
+):
+    score_set = await setup_records_files_and_variants_with_mapping(
+        session,
+        async_client,
+        data_files,
+        TEST_MINIMAL_SEQ_SCORESET,
+        standalone_worker_context,
+    )
+
+    with (
+        patch.object(ClinGenAlleleRegistryService, "dispatch_submissions", return_value=[TEST_CLINGEN_ALLELE_OBJECT]),
+        patch("mavedb.worker.jobs.CAR_SUBMISSION_ENDPOINT", "https://reg.test.genome.network/pytest"),
+    ):
+        result = await submit_score_set_mappings_to_car(standalone_worker_context, uuid4().hex, score_set.id)
+
+    mapped_variants_with_caid_for_score_set = session.scalars(
+        select(MappedVariant)
+        .join(Variant)
+        .join(ScoreSetDbModel)
+        .filter(ScoreSetDbModel.urn == score_set.urn, MappedVariant.clingen_allele_id.is_not(None))
+    ).all()
+
+    assert len(mapped_variants_with_caid_for_score_set) == score_set.num_variants
+
+    assert result["success"]
+    assert not result["retried"]
+    assert result["enqueued_job"] is not None
+
+
+@pytest.mark.asyncio
+async def test_submit_score_set_mappings_to_car_exception_in_setup(
+    setup_worker_db, standalone_worker_context, session, async_client, data_files, arq_worker, arq_redis
+):
+    score_set = await setup_records_files_and_variants_with_mapping(
+        session,
+        async_client,
+        data_files,
+        TEST_MINIMAL_SEQ_SCORESET,
+        standalone_worker_context,
+    )
+
+    with patch(
+        "mavedb.worker.jobs.setup_job_state",
+        side_effect=Exception(),
+    ):
+        result = await submit_score_set_mappings_to_car(standalone_worker_context, uuid4().hex, score_set.id)
+
+    assert not result["success"]
+    assert not result["retried"]
+    assert not result["enqueued_job"]
+
+
+@pytest.mark.asyncio
+async def test_submit_score_set_mappings_to_car_no_variants_exist(
+    setup_worker_db, standalone_worker_context, session, async_client, data_files, arq_worker, arq_redis
+):
+    score_set = await setup_records_files_and_variants(
+        session,
+        async_client,
+        data_files,
+        TEST_MINIMAL_SEQ_SCORESET,
+        standalone_worker_context,
+    )
+
+    result = await submit_score_set_mappings_to_car(standalone_worker_context, uuid4().hex, score_set.id)
+
+    assert result["success"]
+    assert not result["retried"]
+    assert not result["enqueued_job"]
+
+
+@pytest.mark.asyncio
+async def test_submit_score_set_mappings_to_car_exception_in_hgvs_dict_creation(
+    setup_worker_db, standalone_worker_context, session, async_client, data_files, arq_worker, arq_redis
+):
+    score_set = await setup_records_files_and_variants_with_mapping(
+        session,
+        async_client,
+        data_files,
+        TEST_MINIMAL_SEQ_SCORESET,
+        standalone_worker_context,
+    )
+
+    with patch(
+        "mavedb.worker.jobs.get_hgvs_from_post_mapped",
+        side_effect=Exception(),
+    ):
+        result = await submit_score_set_mappings_to_car(standalone_worker_context, uuid4().hex, score_set.id)
+
+    assert not result["success"]
+    assert not result["retried"]
+    assert not result["enqueued_job"]
+
+
+@pytest.mark.asyncio
+async def test_submit_score_set_mappings_to_car_exception_during_submission(
+    setup_worker_db, standalone_worker_context, session, async_client, data_files, arq_worker, arq_redis
+):
+    score_set = await setup_records_files_and_variants_with_mapping(
+        session,
+        async_client,
+        data_files,
+        TEST_MINIMAL_SEQ_SCORESET,
+        standalone_worker_context,
+    )
+
+    with (
+        patch.object(ClinGenAlleleRegistryService, "dispatch_submissions", side_effect=Exception()),
+        patch("mavedb.worker.jobs.CAR_SUBMISSION_ENDPOINT", "https://reg.test.genome.network/pytest"),
+    ):
+        result = await submit_score_set_mappings_to_car(standalone_worker_context, uuid4().hex, score_set.id)
+
+    assert not result["success"]
+    assert not result["retried"]
+    assert not result["enqueued_job"]
+
+
+@pytest.mark.asyncio
+async def test_submit_score_set_mappings_to_car_exception_in_allele_association(
+    setup_worker_db, standalone_worker_context, session, async_client, data_files, arq_worker, arq_redis
+):
+    score_set = await setup_records_files_and_variants_with_mapping(
+        session,
+        async_client,
+        data_files,
+        TEST_MINIMAL_SEQ_SCORESET,
+        standalone_worker_context,
+    )
+
+    with (
+        patch("mavedb.worker.jobs.get_allele_registry_associations", side_effect=Exception()),
+        patch("mavedb.worker.jobs.CAR_SUBMISSION_ENDPOINT", "https://reg.test.genome.network/pytest"),
+    ):
+        result = await submit_score_set_mappings_to_car(standalone_worker_context, uuid4().hex, score_set.id)
+
+    assert not result["success"]
+    assert not result["retried"]
+    assert not result["enqueued_job"]
+
+
+@pytest.mark.asyncio
+async def test_submit_score_set_mappings_to_car_exception_during_ldh_enqueue(
+    setup_worker_db, standalone_worker_context, session, async_client, data_files, arq_worker, arq_redis
+):
+    score_set = await setup_records_files_and_variants_with_mapping(
+        session,
+        async_client,
+        data_files,
+        TEST_MINIMAL_SEQ_SCORESET,
+        standalone_worker_context,
+    )
+
+    with (
+        patch("mavedb.worker.jobs.CAR_SUBMISSION_ENDPOINT", "https://reg.test.genome.network/pytest"),
+        patch.object(ClinGenAlleleRegistryService, "dispatch_submissions", return_value=[TEST_CLINGEN_ALLELE_OBJECT]),
+        patch.object(arq.ArqRedis, "enqueue_job", side_effect=Exception()),
+    ):
+        result = await submit_score_set_mappings_to_car(standalone_worker_context, uuid4().hex, score_set.id)
+
+    mapped_variants_with_caid_for_score_set = session.scalars(
+        select(MappedVariant)
+        .join(Variant)
+        .join(ScoreSetDbModel)
+        .filter(ScoreSetDbModel.urn == score_set.urn, MappedVariant.clingen_allele_id.is_not(None))
+    ).all()
+
+    assert len(mapped_variants_with_caid_for_score_set) == score_set.num_variants
+
+    assert not result["success"]
+    assert not result["retried"]
+    assert not result["enqueued_job"]
+
+
+############################################################################################################################################
+# ClinGen LDH Submission
 ############################################################################################################################################
 
 

--- a/tests/worker/test_jobs.py
+++ b/tests/worker/test_jobs.py
@@ -1782,7 +1782,7 @@ async def test_submit_score_set_mappings_to_ldh_exception_in_hgvs_generation(
     )
 
     with patch(
-        "mavedb.lib.variants.hgvs_from_mapped_variant",
+        "mavedb.lib.variants.get_hgvs_from_post_mapped",
         side_effect=Exception(),
     ):
         result = await submit_score_set_mappings_to_ldh(standalone_worker_context, uuid4().hex, score_set.id)


### PR DESCRIPTION
This pull request introduces significant updates to support ClinGen Allele Registry integration. Highlights include the addition of a new service for interacting with the ClinGen Allele Registry API, enhancements to typed dictionaries for ClinGen data, and the relocation of HGVS-related utilities to a dedicated module.

### ClinGen Allele Registry Integration:
* Introduced `ClinGenAlleleRegistryService` in `src/mavedb/lib/clingen/services.py` for authenticating with Genboree and submitting HGVS strings to the ClinGen Allele Registry. This includes methods for constructing authenticated URLs and dispatching submissions.
* Added a helper function `get_allele_registry_associations` to map HGVS strings to ClinGen Canonical Allele IDs (CAIDs) based on submission responses.
* Added `CAR_SUBMISSION_ENDPOINT` environment variable to `settings/.env.template` and `src/mavedb/lib/clingen/constants.py` for configuring the ClinGen Allele Registry submission endpoint. [[1]](diffhunk://#diff-27a34742a1e20d6b74e53969acc9ccc01f7a9d84b03c1814ba49e38fab63b2a5L68-R75) [[2]](diffhunk://#diff-0108bbe9d2e8692fe0984de8541ccf6190ac425353a08e3b46e75226a9e338bfR10-R11)

### HGVS-Related Refactoring:
* Moved HGVS-related utilities (`hgvs_from_vrs_allele`, `get_hgvs_from_post_mapped`, `is_hgvs_g`, `is_hgvs_p`) to a new module `src/mavedb/lib/variants.py` for better modularity. [[1]](diffhunk://#diff-1eac3122319c0ba2f5bd5a7c71acaff57774e2f314da68b37a3d1100c696b981L1-R6) [[2]](diffhunk://#diff-1eac3122319c0ba2f5bd5a7c71acaff57774e2f314da68b37a3d1100c696b981L12-R65)
* Updated `variant_to_csv_row` in `src/mavedb/lib/score_sets.py` to use the new `get_hgvs_from_post_mapped` utility.
* Removed redundant HGVS-related methods and regex definitions from `src/mavedb/lib/score_sets.py` after migration to the new module.

### Typed Dictionary Enhancements:
* Added detailed typed dictionaries (`ClinGenAllele`, `ClinGenAlleleDefinition`, `ClinGenExternalRecord`) in `src/mavedb/lib/types/clingen.py` for modeling ClinGen Allele Registry responses.

### Code Organization and Cleanup:
* Renamed `src/mavedb/lib/clingen/linked_data_hub.py` to `src/mavedb/lib/clingen/services.py` to reflect its expanded functionality.
* Improved error handling for VRS allele parsing in `src/mavedb/lib/variants.py` to raise descriptive exceptions for unsupported formats.