### PR TITLE
Explicit Score Range Boundary Handling

### DIFF
--- a/src/mavedb/view_models/score_range.py
+++ b/src/mavedb/view_models/score_range.py
@@ -109,6 +109,17 @@ class ScoreRangesBase(BaseModel):
                 else operator.ge
             )
 
+            # If both ranges have inclusive bounds and their bounds intersect, we consider them overlapping.
+            if (
+                range_with_min_value.inclusive_upper_bound
+                and range_with_non_min_value.inclusive_lower_bound
+                and (
+                    inf_or_float(range_with_min_value.range[1], False)
+                    == inf_or_float(range_with_non_min_value.range[0], True)
+                )
+            ):
+                return True
+
             # Since we have ordered the ranges, it's a guarantee that the lower bound of the first range is less
             # than or equal to the lower bound of the second range. If the upper bound of the first range is greater
             # than or equal to the lower bound of the second range, then the two ranges overlap. Note that if either

--- a/src/mavedb/view_models/score_range.py
+++ b/src/mavedb/view_models/score_range.py
@@ -103,15 +103,19 @@ class ScoreRangesBase(BaseModel):
                 range_with_min_value = range_check
                 range_with_non_min_value = range_test
 
-            lower_bound_comparator = operator.le if range_with_min_value.inclusive_lower_bound else operator.lt
-            upper_bound_comparator = operator.ge if range_with_non_min_value.inclusive_upper_bound else operator.gt
+            adjacent_boundary_comparator = (
+                operator.gt
+                if range_with_min_value.inclusive_upper_bound or range_with_non_min_value.inclusive_lower_bound
+                else operator.ge
+            )
 
-            if upper_bound_comparator(
+            # Since we have ordered the ranges, it's a guarantee that the lower bound of the first range is less
+            # than or equal to the lower bound of the second range. If the upper bound of the first range is greater
+            # than or equal to the lower bound of the second range, then the two ranges overlap. Note that if either
+            # of these ranges has an inclusive upper or lower bound, we should compare them without the equality operator.
+            if adjacent_boundary_comparator(
                 inf_or_float(range_with_min_value.range[1], False),
                 inf_or_float(range_with_non_min_value.range[0], True),
-            ) and lower_bound_comparator(
-                inf_or_float(range_with_min_value.range[0], True),
-                inf_or_float(range_with_non_min_value.range[1], False),
             ):
                 return True
 

--- a/src/mavedb/view_models/score_range.py
+++ b/src/mavedb/view_models/score_range.py
@@ -1,5 +1,6 @@
+import operator
 from typing import Any, Optional, Literal, Sequence, Union
-from pydantic import validator
+from pydantic import validator, root_validator
 
 from mavedb.lib.validation.exceptions import ValidationError
 from mavedb.lib.validation.utilities import inf_or_float
@@ -26,9 +27,11 @@ class ScoreRangeBase(BaseModel):
     # jsonschema, and fail all tests that access the schema. This may be fixed in pydantic v2,
     # but it's unclear. Even just typing it as Tuple[Any, Any] will generate an invalid schema!
     range: list[Any]  # really: tuple[Union[float, None], Union[float, None]]
+    inclusive_lower_bound: bool = True
+    inclusive_upper_bound: bool = False
 
     @validator("range")
-    def ranges_are_not_backwards(cls, field_value: tuple[Any]):
+    def ranges_are_not_backwards(cls, field_value: list[Any]) -> list[Any]:
         if len(field_value) != 2:
             raise ValidationError("Only a lower and upper bound are allowed.")
 
@@ -41,6 +44,23 @@ class ScoreRangeBase(BaseModel):
             raise ValidationError("The lower and upper bound of the score range may not be the same.")
 
         return field_value
+
+    @root_validator
+    def inclusive_bounds_do_not_include_infinity(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """
+        Ensure that if the lower bound is inclusive, it does not include negative infinity.
+        Similarly, if the upper bound is inclusive, it does not include positive infinity.
+        """
+        range_values = values.get("range")
+        inclusive_lower_bound = values.get("inclusive_lower_bound")
+        inclusive_upper_bound = values.get("inclusive_upper_bound")
+
+        if inclusive_lower_bound and range_values and range_values[0] is None:
+            raise ValidationError("An inclusive lower bound may not include negative infinity.")
+        if inclusive_upper_bound and range_values and range_values[1] is None:
+            raise ValidationError("An inclusive upper bound may not include positive infinity.")
+
+        return values
 
 
 class ScoreRangeModify(ScoreRangeBase):
@@ -70,27 +90,36 @@ class ScoreRangesBase(BaseModel):
 
     @validator("ranges")
     def ranges_do_not_overlap(cls, field_value: Sequence[ScoreRangeBase]) -> Sequence[ScoreRangeBase]:
-        def test_overlap(tp1, tp2) -> bool:
+        def test_overlap(range_test: ScoreRangeBase, range_check: ScoreRangeBase) -> bool:
             # Always check the tuple with the lowest lower bound. If we do not check
             # overlaps in this manner, checking the overlap of (0,1) and (1,2) will
             # yield different results depending on the ordering of tuples.
-            if min(inf_or_float(tp1[0], True), inf_or_float(tp2[0], True)) == inf_or_float(tp1[0], True):
-                tp_with_min_value = tp1
-                tp_with_non_min_value = tp2
+            if min(inf_or_float(range_test.range[0], True), inf_or_float(range_check.range[0], True)) == inf_or_float(
+                range_test.range[0], True
+            ):
+                range_with_min_value = range_test
+                range_with_non_min_value = range_check
             else:
-                tp_with_min_value = tp2
-                tp_with_non_min_value = tp1
+                range_with_min_value = range_check
+                range_with_non_min_value = range_test
 
-            if inf_or_float(tp_with_min_value[1], False) > inf_or_float(
-                tp_with_non_min_value[0], True
-            ) and inf_or_float(tp_with_min_value[0], True) <= inf_or_float(tp_with_non_min_value[1], False):
+            lower_bound_comparator = operator.le if range_with_min_value.inclusive_lower_bound else operator.lt
+            upper_bound_comparator = operator.ge if range_with_non_min_value.inclusive_upper_bound else operator.gt
+
+            if upper_bound_comparator(
+                inf_or_float(range_with_min_value.range[1], False),
+                inf_or_float(range_with_non_min_value.range[0], True),
+            ) and lower_bound_comparator(
+                inf_or_float(range_with_min_value.range[0], True),
+                inf_or_float(range_with_non_min_value.range[1], False),
+            ):
                 return True
 
             return False
 
         for i, range_test in enumerate(field_value):
             for range_check in list(field_value)[i + 1 :]:
-                if test_overlap(range_test.range, range_check.range):
+                if test_overlap(range_test, range_check):
                     raise ValidationError(
                         f"Score ranges may not overlap; `{range_test.label}` ({range_test.range}) overlaps with `{range_check.label}` ({range_check.range})."
                     )

--- a/src/mavedb/view_models/score_set.py
+++ b/src/mavedb/view_models/score_set.py
@@ -181,7 +181,7 @@ class ScoreSetModify(ScoreSetBase):
                 else []
             )
 
-            if pub not in [*primary_publication_identifiers, *secondary_publication_identifiers]:
+            if source not in [*primary_publication_identifiers, *secondary_publication_identifiers]:
                 return False
 
             return True

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -1209,6 +1209,8 @@ TEST_SCORE_SET_NORMAL_RANGE = {
     "label": "test1",
     "classification": "normal",
     "range": (0, 2.0),
+    "inclusive_lower_bound": True,
+    "inclusive_upper_bound": False,
 }
 
 
@@ -1217,6 +1219,8 @@ TEST_SAVED_SCORE_SET_NORMAL_RANGE = {
     "label": "test1",
     "classification": "normal",
     "range": [0.0, 2.0],
+    "inclusiveLowerBound": True,
+    "inclusiveUpperBound": False,
 }
 
 
@@ -1224,6 +1228,8 @@ TEST_SCORE_SET_ABNORMAL_RANGE = {
     "label": "test2",
     "classification": "abnormal",
     "range": (-2.0, 0),
+    "inclusive_lower_bound": True,
+    "inclusive_upper_bound": False,
 }
 
 
@@ -1232,13 +1238,17 @@ TEST_SAVED_SCORE_SET_ABNORMAL_RANGE = {
     "label": "test2",
     "classification": "abnormal",
     "range": [-2.0, 0.0],
+    "inclusiveLowerBound": True,
+    "inclusiveUpperBound": False,
 }
 
 
 TEST_SCORE_SET_NOT_SPECIFIED_RANGE = {
     "label": "test3",
     "classification": "not_specified",
-    "range": (None, -2.0),
+    "range": (-8.0, -2.0),
+    "inclusive_lower_bound": True,
+    "inclusive_upper_bound": False,
 }
 
 
@@ -1246,7 +1256,47 @@ TEST_SAVED_SCORE_SET_NOT_SPECIFIED_RANGE = {
     "recordType": "ScoreRange",
     "label": "test3",
     "classification": "not_specified",
-    "range": [None, -2.0],
+    "range": [-8.0, -2.0],
+    "inclusiveLowerBound": True,
+    "inclusiveUpperBound": False,
+}
+
+
+TEST_SCORE_SET_NEGATIVE_INFINITY_RANGE = {
+    "label": "test4",
+    "classification": "not_specified",
+    "range": (None, 0.0),
+    "inclusive_lower_bound": False,
+    "inclusive_upper_bound": False,
+}
+
+
+TEST_SAVED_SCORE_SET_NEGATIVE_INFINITY_RANGE = {
+    "recordType": "ScoreRange",
+    "label": "test4",
+    "classification": "not_specified",
+    "range": [None, 0.0],
+    "inclusiveLowerBound": False,
+    "inclusiveUpperBound": False,
+}
+
+
+TEST_SCORE_SET_POSITIVE_INFINITY_RANGE = {
+    "label": "test5",
+    "classification": "not_specified",
+    "range": [0.0, None],
+    "inclusive_lower_bound": False,
+    "inclusive_upper_bound": False,
+}
+
+
+TEST_SAVED_SCORE_SET_POSITIVE_INFINITY_RANGE = {
+    "recordType": "ScoreRange",
+    "label": "test5",
+    "classification": "not_specified",
+    "range": [0.0, None],
+    "inclusiveLowerBound": False,
+    "inclusiveUpperBound": False,
 }
 
 

--- a/tests/view_models/test_score_range.py
+++ b/tests/view_models/test_score_range.py
@@ -392,29 +392,36 @@ def test_score_ranges_ranges_may_not_overlap_via_inclusive_bounds(ScoreRangesMod
         InvestigatorScoreRangesModify,
     ],
 )
-def test_score_ranges_ranges_boundaries_may_be_adjacent(ScoreRangesModel):
+@pytest.mark.parametrize(
+    "range_value1, range_value2, orientation",
+    [
+        ([0.0, 2.0], [2.0, 3.0], True),
+        ([0.0, 2.0], [2.0, 3.0], False),
+    ],
+)
+def test_score_ranges_ranges_boundaries_may_be_adjacent(ScoreRangesModel, range_value1, range_value2, orientation):
     range_test = ScoreRange(
         label="Range 1",
         classification="abnormal",
-        range=[0.0, 2.0],
-        inclusive_lower_bound=True,
-        inclusive_upper_bound=False,
+        range=range_value1,
+        inclusive_lower_bound=orientation,
+        inclusive_upper_bound=not orientation,
     )
     range_check = ScoreRange(
         label="Range 2",
         classification="abnormal",
-        range=[2.0, 3.0],
-        inclusive_lower_bound=True,
-        inclusive_upper_bound=False,
+        range=range_value2,
+        inclusive_lower_bound=orientation,
+        inclusive_upper_bound=not orientation,
     )
-    invalid_data = {
+    valid_data = {
         "ranges": [
             range_test,
             range_check,
         ]
     }
 
-    ScoreRangesModel(**invalid_data)
+    ScoreRangesModel(**valid_data)
 
 
 @pytest.mark.parametrize(
@@ -491,31 +498,40 @@ def test_score_ranges_pillar_project_ranges_may_not_overlap_via_inclusive_bounds
         PillarProjectScoreRangesModify,
     ],
 )
-def test_score_ranges_pillar_project_ranges_boundaries_may_be_adjacent(ScoreRangesModel):
+@pytest.mark.parametrize(
+    "range_value1, range_value2, orientation",
+    [
+        ([0.0, 2.0], [2.0, 3.0], True),
+        ([0.0, 2.0], [2.0, 3.0], False),
+    ],
+)
+def test_score_ranges_pillar_project_ranges_boundaries_may_be_adjacent(
+    ScoreRangesModel, range_value1, range_value2, orientation
+):
     range_test = PillarProjectScoreRange(
         label="Range 1",
         classification="abnormal",
-        range=[0.0, 2.0],
+        range=range_value1,
         evidence_strength=2,
-        inclusive_lower_bound=True,
-        inclusive_upper_bound=False,
+        inclusive_lower_bound=orientation,
+        inclusive_upper_bound=not orientation,
     )
     range_check = PillarProjectScoreRange(
         label="Range 2",
         classification="abnormal",
-        range=[2.0, 3.0],
+        range=range_value2,
         evidence_strength=3,
-        inclusive_lower_bound=True,
-        inclusive_upper_bound=False,
+        inclusive_lower_bound=orientation,
+        inclusive_upper_bound=not orientation,
     )
-    invalid_data = {
+    valid_data = {
         "ranges": [
             range_test,
             range_check,
         ]
     }
 
-    ScoreRangesModel(**invalid_data)
+    ScoreRangesModel(**valid_data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request enhances the handling and validation of score range boundaries in the `ScoreRange` models. It introduces explicit inclusivity flags for range endpoints, enforces stricter validation to prevent invalid configurations (such as inclusive infinity bounds), and updates overlap detection logic to respect these inclusivity flags. The test suite is expanded to cover these new behaviors.

**Score Range Model Enhancements:**

* Added `inclusive_lower_bound` and `inclusive_upper_bound` boolean fields to `ScoreRangeBase` to explicitly indicate whether the lower and upper bounds are inclusive.
* Implemented a `root_validator` to ensure that inclusive bounds cannot include infinity, preventing configurations like an inclusive lower bound at negative infinity.

**Validation Logic Improvements:**

* Refined the overlap detection logic in `ScoreRangesBase` to account for inclusive/exclusive boundaries, ensuring adjacent ranges are handled correctly.

**Test Suite Updates:**

* Added and updated constants in `tests/helpers/constants.py` to include the new inclusivity fields and provide test cases for ranges involving infinities. [[1]](diffhunk://#diff-d98952865898f668937bf1a48bc66d4aaac8a5447b3801bc08344b25eb212b42R1212-R1213) [[2]](diffhunk://#diff-d98952865898f668937bf1a48bc66d4aaac8a5447b3801bc08344b25eb212b42R1222-R1232) [[3]](diffhunk://#diff-d98952865898f668937bf1a48bc66d4aaac8a5447b3801bc08344b25eb212b42R1241-R1299)
* Expanded tests in `tests/view_models/test_score_range.py` to verify correct handling of inclusive bounds, prevention of inclusive infinity, and proper overlap detection with various inclusivity configurations. [[1]](diffhunk://#diff-74fd0993445438abe39895802f912911bdd393f4ae34959cd66734249d8de58fL55-R63) [[2]](diffhunk://#diff-74fd0993445438abe39895802f912911bdd393f4ae34959cd66734249d8de58fR73-R78) [[3]](diffhunk://#diff-74fd0993445438abe39895802f912911bdd393f4ae34959cd66734249d8de58fR200-R235) [[4]](diffhunk://#diff-74fd0993445438abe39895802f912911bdd393f4ae34959cd66734249d8de58fR345-R426) [[5]](diffhunk://#diff-74fd0993445438abe39895802f912911bdd393f4ae34959cd66734249d8de58fR455-R536)

**Bug Fix:**

* Fixed a variable name in `_check_source_in_score_set` to correctly check for the presence of a source in publication identifiers.