### PR TITLE
fixed: Publication wish NULL publication journal causing 500 errors on /journals route

### DIFF
--- a/src/mavedb/routers/publication_identifiers.py
+++ b/src/mavedb/routers/publication_identifiers.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Session
 from starlette.convertors import Convertor, register_url_convertor
@@ -121,7 +121,9 @@ def list_publication_journal_names(*, db: Session = Depends(deps.get_db)) -> Any
     List distinct journal names, in alphabetical order.
     """
 
-    items = db.query(PublicationIdentifier).all()
+    items = db.scalars(
+        select(PublicationIdentifier).where(PublicationIdentifier.publication_journal.is_not(None))
+    ).all()
     journals = map(lambda item: item.publication_journal, items)
     return sorted(list(set(journals)))
 

--- a/tests/helpers/constants.py
+++ b/tests/helpers/constants.py
@@ -122,9 +122,22 @@ TEST_VALID_POST_MAPPED_VRS_HAPLOTYPE = {
     "members": [TEST_VALID_POST_MAPPED_VRS_ALLELE, TEST_VALID_POST_MAPPED_VRS_ALLELE],
 }
 
+TEST_PUBMED_PUBLICATION = {
+    "identifier": TEST_PUBMED_IDENTIFIER,
+    "db_name": "PubMed",
+    "title": "None",
+    "authors": [],
+    "abstract": "test",
+    "doi": "test",
+    "publication_year": 1999,
+    "publication_journal": "test",
+    "url": "http://www.ncbi.nlm.nih.gov/pubmed/20711194",
+    "reference_html": ". None. test. 1999; (Unknown volume):(Unknown pages). test",
+}
+
 SAVED_PUBMED_PUBLICATION = {
     "recordType": "PublicationIdentifier",
-    "identifier": "20711194",
+    "identifier": TEST_PUBMED_IDENTIFIER,
     "dbName": "PubMed",
     "title": "None",
     "authors": [],

--- a/tests/routers/conftest.py
+++ b/tests/routers/conftest.py
@@ -7,6 +7,7 @@ from mavedb.models.clinical_control import ClinicalControl
 from mavedb.models.controlled_keyword import ControlledKeyword
 from mavedb.models.contributor import Contributor
 from mavedb.models.enums.user_role import UserRole
+from mavedb.models.publication_identifier import PublicationIdentifier
 from mavedb.models.gnomad_variant import GnomADVariant
 from mavedb.models.license import License
 from mavedb.models.role import Role
@@ -25,6 +26,7 @@ from tests.helpers.constants import (
     EXTRA_LICENSE,
     TEST_SAVED_TAXONOMY,
     TEST_USER,
+    TEST_PUBMED_PUBLICATION,
     TEST_GNOMAD_VARIANT,
 )
 
@@ -40,6 +42,7 @@ def setup_router_db(session):
     db.add(User(**TEST_USER))
     db.add(User(**EXTRA_USER))
     db.add(User(**ADMIN_USER, role_objs=[Role(name=UserRole.admin)]))
+    db.add(PublicationIdentifier(**TEST_PUBMED_PUBLICATION))
     db.add(Taxonomy(**TEST_SAVED_TAXONOMY))
     db.add(License(**TEST_LICENSE))
     db.add(License(**TEST_INACTIVE_LICENSE))

--- a/tests/routers/test_publication_identifiers.py
+++ b/tests/routers/test_publication_identifiers.py
@@ -1,0 +1,86 @@
+import pytest  # noqa: F401
+
+from sqlalchemy import select, delete
+
+from mavedb.models.publication_identifier import PublicationIdentifier
+
+from tests.helpers.constants import TEST_PUBMED_PUBLICATION
+
+
+# TODO#497: Expand test coverage for publication identifier routes.
+
+
+def test_show_publication_identifiers_multiple_exist(client, setup_router_db, session):
+    """
+    Test the endpoint for listing publication identifiers when multiple exist.
+    """
+    new_journal_name = "New Journal"
+
+    # Create a duplicate publication identifier (skip PK/dates)
+    existing_item = session.scalars(select(PublicationIdentifier)).first()
+    duplicate_item = PublicationIdentifier(
+        identifier=existing_item.identifier,
+        db_name=existing_item.db_name,
+        db_version=existing_item.db_version,
+        title=existing_item.title,
+        abstract=existing_item.abstract,
+        authors=existing_item.authors,
+        doi=existing_item.doi,
+        publication_year=existing_item.publication_year,
+        publication_journal=new_journal_name,  # override for clarity in assertions
+        url=existing_item.url,
+        reference_html=existing_item.reference_html,
+    )
+    session.add(duplicate_item)
+    session.commit()
+
+    response = client.get("/api/v1/publication-identifiers/journals")
+
+    # Assert the response
+    assert response.status_code == 200
+    assert response.json() == sorted([TEST_PUBMED_PUBLICATION["publication_journal"], new_journal_name])
+
+
+def test_show_publication_journals_one_exists(client, setup_router_db):
+    """
+    Test the endpoint for listing publication journals when one exists.
+    """
+
+    # Call the API endpoint
+    response = client.get("/api/v1/publication-identifiers/journals")
+
+    # Assert the response
+    assert response.status_code == 200
+    assert response.json() == [TEST_PUBMED_PUBLICATION["publication_journal"]]
+
+
+def test_show_publication_journals_none_type_journal(client, setup_router_db, session):
+    """
+    Test the endpoint for listing publication journals when one is of type None.
+    """
+    item = session.scalars(select(PublicationIdentifier)).first()
+    item.publication_journal = None
+    session.add(item)
+    session.commit()
+
+    # Call the API endpoint
+    response = client.get("/api/v1/publication-identifiers/journals")
+
+    # Assert the response
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_show_publication_journals_none_exist(client, setup_router_db, session):
+    """
+    Test the endpoint for listing publication journals when none are available.
+    """
+    session.execute(delete(PublicationIdentifier))
+    session.commit()
+
+    # Call the API endpoint
+    response = client.get("/api/v1/publication-identifiers/journals")
+
+    # Assert the response
+    assert response.status_code == 200
+    assert response.json() == []

--- a/tests/routers/test_publication_identifiers.py
+++ b/tests/routers/test_publication_identifiers.py
@@ -1,6 +1,12 @@
+# ruff: noqa: E402
+
 import pytest  # noqa: F401
 
 from sqlalchemy import select, delete
+
+arq = pytest.importorskip("arq")
+cdot = pytest.importorskip("cdot")
+fastapi = pytest.importorskip("fastapi")
 
 from mavedb.models.publication_identifier import PublicationIdentifier
 


### PR DESCRIPTION
When a publication had a NULL publication journal, it would still be pulled through to the set and the sorted() call would fail when comparing a str type with a Nonetype. NULL entries are not filtered prior to sorting the resulting set.

See: https://brotmanbaty.slack.com/archives/C055J69KT1T/p1755637168865629