### PR TITLE
Score set search result optimization

### DIFF
--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -305,10 +305,10 @@ def fetch_score_set_search_filter_options(db: Session, owner_or_contributor: Opt
     if not score_sets:
         score_sets = []
 
-    target_category_counter = Counter()
-    target_name_counter = Counter()
-    target_organism_name_counter = Counter()
-    target_accession_counter = Counter()
+    target_category_counter: Counter[str] = Counter()
+    target_name_counter: Counter[str] = Counter()
+    target_organism_name_counter: Counter[str] = Counter()
+    target_accession_counter: Counter[str] = Counter()
     for score_set in score_sets:
         for target in getattr(score_set, "target_genes", []):
 
@@ -338,9 +338,9 @@ def fetch_score_set_search_filter_options(db: Session, owner_or_contributor: Opt
     target_organism_names = [{"value": value, "count": count} for value, count in target_organism_name_counter.items()]
     target_accessions = [{"value": value, "count": count} for value, count in target_accession_counter.items()]
 
-    publication_author_name_counter = Counter()
-    publication_db_name_counter = Counter()
-    publication_journal_counter = Counter()
+    publication_author_name_counter: Counter[str] = Counter()
+    publication_db_name_counter: Counter[str] = Counter()
+    publication_journal_counter: Counter[str] = Counter()
     for score_set in score_sets:
         for publication_association in getattr(score_set, "publication_identifier_associations", []):
             publication = getattr(publication_association, "publication", None)

--- a/src/mavedb/routers/score_sets.py
+++ b/src/mavedb/routers/score_sets.py
@@ -45,6 +45,7 @@ from mavedb.lib.logging.context import (
 from mavedb.lib.permissions import Action, assert_permission, has_permission
 from mavedb.lib.score_sets import (
     csv_data_to_df,
+    fetch_score_set_search_filter_options,
     find_meta_analyses_for_experiment_sets,
     get_score_set_variants_as_csv,
     variants_to_csv_rows,
@@ -74,7 +75,7 @@ from mavedb.models.target_gene import TargetGene
 from mavedb.models.target_sequence import TargetSequence
 from mavedb.models.variant import Variant
 from mavedb.view_models import mapped_variant, score_set, clinical_control, score_range, gnomad_variant
-from mavedb.view_models.search import ScoreSetsSearch, ScoreSetsSearchResponse
+from mavedb.view_models.search import ScoreSetsSearch, ScoreSetsSearchFilterOptionsResponse, ScoreSetsSearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +159,14 @@ def search_score_sets(
         "score_sets": enriched_score_sets,
         "num_score_sets": num_score_sets
     }
+
+
+@router.post("/score-sets/search/filter-options", status_code=200, response_model=ScoreSetsSearchFilterOptionsResponse)
+def get_filter_options_for_search(
+    search: ScoreSetsSearch,
+    db: Session = Depends(deps.get_db),
+) -> Any:
+    return fetch_score_set_search_filter_options(db, None, search)
 
 
 @router.get("/score-sets/mapped-genes", status_code=200, response_model=dict[str, list[str]])

--- a/src/mavedb/view_models/search.py
+++ b/src/mavedb/view_models/search.py
@@ -38,5 +38,26 @@ class ScoreSetsSearchResponse(BaseModel):
         from_attributes = True
 
 
+class ScoreSetsSearchFilterOption(BaseModel):
+    value: str
+    count: int
+
+    class Config:
+        from_attributes = True
+
+
+class ScoreSetsSearchFilterOptionsResponse(BaseModel):
+    target_gene_categories: list[ScoreSetsSearchFilterOption]
+    target_gene_names: list[ScoreSetsSearchFilterOption]
+    target_organism_names: list[ScoreSetsSearchFilterOption]
+    target_accessions: list[ScoreSetsSearchFilterOption]
+    publication_author_names: list[ScoreSetsSearchFilterOption]
+    publication_db_names: list[ScoreSetsSearchFilterOption]
+    publication_journals: list[ScoreSetsSearchFilterOption]
+
+    class Config:
+        from_attributes = True
+
+
 class TextSearch(BaseModel):
     text: Optional[str] = None

--- a/src/mavedb/view_models/search.py
+++ b/src/mavedb/view_models/search.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from mavedb.view_models.base.base import BaseModel
+from mavedb.view_models.score_set import SavedScoreSet, ShortScoreSet
 
 
 class ExperimentsSearch(BaseModel):
@@ -26,6 +27,15 @@ class ScoreSetsSearch(BaseModel):
     publication_identifiers: Optional[list[str]] = None
     keywords: Optional[list[str]] = None
     text: Optional[str] = None
+    limit: Optional[int] = None
+
+
+class ScoreSetsSearchResponse(BaseModel):
+    score_sets: list[ShortScoreSet]
+    num_score_sets: int
+
+    class Config:
+        from_attributes = True
 
 
 class TextSearch(BaseModel):

--- a/tests/routers/test_score_set.py
+++ b/tests/routers/test_score_set.py
@@ -1704,7 +1704,8 @@ def test_search_private_score_sets_no_match(session, data_provider, client, setu
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 0
+    assert response.json()["num_score_sets"] == 0
+    assert len(response.json()["score_sets"]) == 0
 
 
 def test_search_private_score_sets_match(session, data_provider, client, setup_router_db, data_files):
@@ -1715,8 +1716,9 @@ def test_search_private_score_sets_match(session, data_provider, client, setup_r
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["title"] == score_set["title"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["title"] == published_score_set["urn"]
 
 
 def test_search_private_score_sets_urn_match(session, data_provider, client, setup_router_db, data_files):
@@ -1727,8 +1729,9 @@ def test_search_private_score_sets_urn_match(session, data_provider, client, set
     search_payload = {"urn": score_set["urn"]}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["urn"] == score_set["urn"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["urn"] == score_set["urn"]
 
 
 # There is space in the end of test urn. The search result returned nothing before.
@@ -1741,8 +1744,9 @@ def test_search_private_score_sets_urn_with_space_match(session, data_provider, 
     search_payload = {"urn": urn_with_space}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["urn"] == score_set["urn"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["urn"] == score_set["urn"]
 
 
 def test_search_others_private_score_sets_no_match(session, data_provider, client, setup_router_db, data_files):
@@ -1754,7 +1758,8 @@ def test_search_others_private_score_sets_no_match(session, data_provider, clien
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 0
+    assert response.json()["num_score_sets"] == 0
+    assert len(response.json()["score_sets"]) == 0
 
 
 def test_search_others_private_score_sets_match(session, data_provider, client, setup_router_db, data_files):
@@ -1766,7 +1771,8 @@ def test_search_others_private_score_sets_match(session, data_provider, client, 
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 0
+    assert response.json()["num_score_sets"] == 0
+    assert len(response.json()["score_sets"]) == 0
 
 
 def test_search_others_private_score_sets_urn_match(session, data_provider, client, setup_router_db, data_files):
@@ -1778,7 +1784,8 @@ def test_search_others_private_score_sets_urn_match(session, data_provider, clie
     search_payload = {"urn": score_set["urn"]}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 0
+    assert response.json()["num_score_sets"] == 0
+    assert len(response.json()["score_sets"]) == 0
 
 
 # There is space in the end of test urn. The search result returned nothing before.
@@ -1794,7 +1801,8 @@ def test_search_others_private_score_sets_urn_with_space_match(
     search_payload = {"urn": urn_with_space}
     response = client.post("/api/v1/me/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 0
+    assert response.json()["num_score_sets"] == 0
+    assert len(response.json()["score_sets"]) == 0
 
 
 def test_search_public_score_sets_no_match(session, data_provider, client, setup_router_db, data_files):
@@ -1809,7 +1817,8 @@ def test_search_public_score_sets_no_match(session, data_provider, client, setup
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 0
+    assert response.json()["num_score_sets"] == 0
+    assert len(response.json()["score_sets"]) == 0
 
 
 def test_search_public_score_sets_match(session, data_provider, client, setup_router_db, data_files):
@@ -1824,8 +1833,9 @@ def test_search_public_score_sets_match(session, data_provider, client, setup_ro
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["title"] == score_set["title"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["title"] == score_set["title"]
 
 
 def test_search_public_score_sets_urn_with_space_match(session, data_provider, client, setup_router_db, data_files):
@@ -1841,8 +1851,9 @@ def test_search_public_score_sets_urn_with_space_match(session, data_provider, c
     search_payload = {"urn": urn_with_space}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["urn"] == published_score_set["urn"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["urn"] == published_score_set["urn"]
 
 
 def test_search_others_public_score_sets_no_match(session, data_provider, client, setup_router_db, data_files):
@@ -1859,8 +1870,8 @@ def test_search_others_public_score_sets_no_match(session, data_provider, client
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 0
-
+    assert response.json()["num_score_sets"] == 0
+    assert len(response.json()["score_sets"]) == 0
 
 def test_search_others_public_score_sets_match(session, data_provider, client, setup_router_db, data_files):
     experiment = create_experiment(client, {"title": "Experiment 1"})
@@ -1877,8 +1888,9 @@ def test_search_others_public_score_sets_match(session, data_provider, client, s
     search_payload = {"text": "fnord"}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["title"] == published_score_set["title"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["title"] == published_score_set["title"]
 
 
 def test_search_others_public_score_sets_urn_match(session, data_provider, client, setup_router_db, data_files):
@@ -1894,9 +1906,10 @@ def test_search_others_public_score_sets_urn_match(session, data_provider, clien
     search_payload = {"urn": score_set["urn"]}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["urn"] == published_score_set["urn"]
-
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["urn"] == published_score_set["urn"]
+    
 
 def test_search_others_public_score_sets_urn_with_space_match(
     session, data_provider, client, setup_router_db, data_files
@@ -1914,8 +1927,9 @@ def test_search_others_public_score_sets_urn_with_space_match(
     search_payload = {"urn": urn_with_space}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["urn"] == published_score_set["urn"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["urn"] == published_score_set["urn"]
 
 
 def test_search_private_score_sets_not_showing_public_score_set(
@@ -1934,8 +1948,9 @@ def test_search_private_score_sets_not_showing_public_score_set(
     search_payload = {"published": False}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["urn"] == score_set_2["urn"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["urn"] == score_set_2["urn"]
 
 
 def test_search_public_score_sets_not_showing_private_score_set(
@@ -1954,8 +1969,9 @@ def test_search_public_score_sets_not_showing_private_score_set(
     search_payload = {"published": True}
     response = client.post("/api/v1/score-sets/search", json=search_payload)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["urn"] == published_score_set_1["urn"]
+    assert response.json()["num_score_sets"] == 1
+    assert len(response.json()["score_sets"]) == 1
+    assert response.json()["score_sets"][0]["urn"] == published_score_set_1["urn"]
 
 
 ########################################################################################################################


### PR DESCRIPTION
- Add a limit option to score set search queries. Require a limit of at most 100 for searches of all score sets, while searches for the user's own score sets can have no limit.
- Extract the score set search query filter clause logic into a new function.
- Use limit + 1 in the search query, and if limit is exceeded, run a second query to count available rows. In either case, return the number of available rows with the limited search result.
- Instead of searching all score sets and then replacing un-superseded ones with their successors, revise the database query to search only un-superseded score sets.
- In the main search endpoint (but not in the "my score sets" endpoint), mandate that the search be only for published score sets.
- Add an endpoint to obtain search filter options based on a given score set search.
- Add an endpoint to obtain search filter options based on a given score set search.