### PR TITLE
Allow ranges to contain a standalone baseline score

### DIFF
--- a/src/mavedb/lib/annotation/classification.py
+++ b/src/mavedb/lib/annotation/classification.py
@@ -33,7 +33,7 @@ def functional_classification_of_variant(
     # This view model object is much simpler to work with.
     score_ranges = ScoreSetRanges(**mapped_variant.variant.score_set.score_ranges).investigator_provided
 
-    if not score_ranges:
+    if not score_ranges or not score_ranges.ranges:
         raise ValueError(
             f"Variant {mapped_variant.variant.urn} does not have investigator-provided score ranges."
             " Unable to classify functional impact."
@@ -71,7 +71,7 @@ def zeiberg_calibration_clinical_classification_of_variant(
 
     score_ranges = ScoreSetRanges(**mapped_variant.variant.score_set.score_ranges).zeiberg_calibration
 
-    if not score_ranges:
+    if not score_ranges or not score_ranges.ranges:
         raise ValueError(
             f"Variant {mapped_variant.variant.urn} does not have pillar project score ranges."
             " Unable to classify clinical impact."

--- a/src/mavedb/lib/annotation/util.py
+++ b/src/mavedb/lib/annotation/util.py
@@ -162,7 +162,7 @@ def _can_annotate_variant_base_assumptions(mapped_variant: MappedVariant) -> boo
     return True
 
 
-def _variant_score_ranges_have_required_keys_for_annotation(
+def _variant_score_ranges_have_required_keys_and_ranges_for_annotation(
     mapped_variant: MappedVariant, key_options: list[str]
 ) -> bool:
     """
@@ -173,7 +173,8 @@ def _variant_score_ranges_have_required_keys_for_annotation(
         key_options (list[str]): List of possible score range keys to check for in the score set.
 
     Returns:
-        bool: False if none of the required keys are found or if all found keys have None values.
+        bool: False if none of the required keys are found or if all found keys have None values or if all found keys
+              do not have range data.
               Returns True (implicitly) if at least one required key exists with a non-None value.
     """
     if mapped_variant.variant.score_set.score_ranges is None:
@@ -182,6 +183,7 @@ def _variant_score_ranges_have_required_keys_for_annotation(
     if not any(
         range_key in mapped_variant.variant.score_set.score_ranges
         and mapped_variant.variant.score_set.score_ranges[range_key] is not None
+        and mapped_variant.variant.score_set.score_ranges[range_key]["ranges"]
         for range_key in key_options
     ):
         return False
@@ -209,14 +211,14 @@ def can_annotate_variant_for_pathogenicity_evidence(mapped_variant: MappedVarian
     Notes:
         The function performs two main validation checks:
         1. Basic annotation assumptions via _can_annotate_variant_base_assumptions
-        2. Required clinical range keys via _variant_score_ranges_have_required_keys_for_annotation
+        2. Required clinical range keys via _variant_score_ranges_have_required_keys_and_ranges_for_annotation
 
         Both checks must pass for the variant to be considered eligible for
         pathogenicity evidence annotation.
     """
     if not _can_annotate_variant_base_assumptions(mapped_variant):
         return False
-    if not _variant_score_ranges_have_required_keys_for_annotation(mapped_variant, CLINICAL_RANGES):
+    if not _variant_score_ranges_have_required_keys_and_ranges_for_annotation(mapped_variant, CLINICAL_RANGES):
         return False
 
     return True
@@ -245,7 +247,7 @@ def can_annotate_variant_for_functional_statement(mapped_variant: MappedVariant)
     """
     if not _can_annotate_variant_base_assumptions(mapped_variant):
         return False
-    if not _variant_score_ranges_have_required_keys_for_annotation(mapped_variant, FUNCTIONAL_RANGES):
+    if not _variant_score_ranges_have_required_keys_and_ranges_for_annotation(mapped_variant, FUNCTIONAL_RANGES):
         return False
 
     return True

--- a/src/mavedb/view_models/score_range.py
+++ b/src/mavedb/view_models/score_range.py
@@ -205,7 +205,9 @@ class BrnichScoreRangesBase(ScoreRangesBase):
 
         if baseline_score is not None:
             if not any(range_model.classification == "normal" for range_model in ranges):
-                raise ValidationError("A baseline score has been provided, but no normal classification range exists.")
+                # For now, we do not raise an error if a baseline score is provided but no normal range exists.
+                # raise ValidationError("A baseline score has been provided, but no normal classification range exists.")
+                return self
 
         normal_ranges = [range_model.range for range_model in ranges if range_model.classification == "normal"]
 

--- a/src/mavedb/view_models/score_range.py
+++ b/src/mavedb/view_models/score_range.py
@@ -339,6 +339,90 @@ class ScottScoreRanges(BrnichScoreRanges, SavedScottScoreRanges):
 
 
 ##############################################################################################################
+# IGVF Coding Variant Focus Group (CVFG) range models
+##############################################################################################################
+
+# Controls: All Variants
+
+
+class IGVFCodingVariantFocusGroupControlScoreRangesBase(BrnichScoreRangesBase):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: All Variants"
+    research_use_only: bool = False
+
+
+class IGVFCodingVariantFocusGroupControlScoreRangesModify(
+    BrnichScoreRangesModify, IGVFCodingVariantFocusGroupControlScoreRangesBase
+):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: All Variants"
+    research_use_only: bool = False
+
+
+class IGVFCodingVariantFocusGroupControlScoreRangesCreate(
+    BrnichScoreRangesCreate, IGVFCodingVariantFocusGroupControlScoreRangesModify
+):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: All Variants"
+    research_use_only: bool = False
+
+
+class SavedIGVFCodingVariantFocusGroupControlScoreRanges(
+    SavedBrnichScoreRanges, IGVFCodingVariantFocusGroupControlScoreRangesBase
+):
+    record_type: str = None  # type: ignore
+
+    title: str = "IGVF Coding Variant Focus Group -- Controls: All Variants"
+    research_use_only: bool = False
+
+    _record_type_factory = record_type_validator()(set_record_type)
+
+
+class IGVFCodingVariantFocusGroupControlScoreRanges(
+    BrnichScoreRanges, SavedIGVFCodingVariantFocusGroupControlScoreRanges
+):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: All Variants"
+    research_use_only: bool = False
+
+
+# Controls: Missense Variants
+
+
+class IGVFCodingVariantFocusGroupMissenseScoreRangesBase(BrnichScoreRangesBase):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: Missense Variants Only"
+    research_use_only: bool = False
+
+
+class IGVFCodingVariantFocusGroupMissenseScoreRangesModify(
+    BrnichScoreRangesModify, IGVFCodingVariantFocusGroupMissenseScoreRangesBase
+):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: Missense Variants Only"
+    research_use_only: bool = False
+
+
+class IGVFCodingVariantFocusGroupMissenseScoreRangesCreate(
+    BrnichScoreRangesCreate, IGVFCodingVariantFocusGroupMissenseScoreRangesModify
+):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: Missense Variants Only"
+    research_use_only: bool = False
+
+
+class SavedIGVFCodingVariantFocusGroupMissenseScoreRanges(
+    SavedBrnichScoreRanges, IGVFCodingVariantFocusGroupMissenseScoreRangesBase
+):
+    record_type: str = None  # type: ignore
+
+    title: str = "IGVF Coding Variant Focus Group -- Controls: Missense Variants Only"
+    research_use_only: bool = False
+
+    _record_type_factory = record_type_validator()(set_record_type)
+
+
+class IGVFCodingVariantFocusGroupMissenseScoreRanges(
+    BrnichScoreRanges, SavedIGVFCodingVariantFocusGroupMissenseScoreRanges
+):
+    title: str = "IGVF Coding Variant Focus Group -- Controls: Missense Variants Only"
+    research_use_only: bool = False
+
+
+##############################################################################################################
 # Zeiberg specific calibration models
 ##############################################################################################################
 
@@ -452,12 +536,20 @@ class ScoreSetRangesBase(BaseModel):
     investigator_provided: Optional[InvestigatorScoreRangesBase] = None
     scott_calibration: Optional[ScottScoreRangesBase] = None
     zeiberg_calibration: Optional[ZeibergCalibrationScoreRangesBase] = None
+    cvfg_all_variants: Optional[IGVFCodingVariantFocusGroupControlScoreRangesBase] = None
+    cvfg_missense_variants: Optional[IGVFCodingVariantFocusGroupMissenseScoreRangesBase] = None
 
     _fields_to_exclude_for_validatation = {"record_type"}
 
     @model_validator(mode="after")
     def score_range_labels_must_be_unique(self: "ScoreSetRangesBase") -> "ScoreSetRangesBase":
-        for container in (self.investigator_provided, self.zeiberg_calibration, self.scott_calibration):
+        for container in (
+            self.investigator_provided,
+            self.zeiberg_calibration,
+            self.scott_calibration,
+            self.cvfg_all_variants,
+            self.cvfg_missense_variants,
+        ):
             if container is None:
                 continue
 
@@ -480,12 +572,16 @@ class ScoreSetRangesModify(ScoreSetRangesBase):
     investigator_provided: Optional[InvestigatorScoreRangesModify] = None
     scott_calibration: Optional[ScottScoreRangesModify] = None
     zeiberg_calibration: Optional[ZeibergCalibrationScoreRangesModify] = None
+    cvfg_all_variants: Optional[IGVFCodingVariantFocusGroupControlScoreRangesModify] = None
+    cvfg_missense_variants: Optional[IGVFCodingVariantFocusGroupMissenseScoreRangesModify] = None
 
 
 class ScoreSetRangesCreate(ScoreSetRangesModify):
     investigator_provided: Optional[InvestigatorScoreRangesCreate] = None
     scott_calibration: Optional[ScottScoreRangesCreate] = None
     zeiberg_calibration: Optional[ZeibergCalibrationScoreRangesCreate] = None
+    cvfg_all_variants: Optional[IGVFCodingVariantFocusGroupControlScoreRangesCreate] = None
+    cvfg_missense_variants: Optional[IGVFCodingVariantFocusGroupMissenseScoreRangesCreate] = None
 
 
 class SavedScoreSetRanges(ScoreSetRangesBase):
@@ -494,6 +590,8 @@ class SavedScoreSetRanges(ScoreSetRangesBase):
     investigator_provided: Optional[SavedInvestigatorScoreRanges] = None
     scott_calibration: Optional[SavedScottScoreRanges] = None
     zeiberg_calibration: Optional[SavedZeibergCalibrationScoreRanges] = None
+    cvfg_all_variants: Optional[SavedIGVFCodingVariantFocusGroupControlScoreRanges] = None
+    cvfg_missense_variants: Optional[SavedIGVFCodingVariantFocusGroupMissenseScoreRanges] = None
 
     _record_type_factory = record_type_validator()(set_record_type)
 
@@ -502,3 +600,5 @@ class ScoreSetRanges(SavedScoreSetRanges):
     investigator_provided: Optional[InvestigatorScoreRanges] = None
     scott_calibration: Optional[ScottScoreRanges] = None
     zeiberg_calibration: Optional[ZeibergCalibrationScoreRanges] = None
+    cvfg_all_variants: Optional[IGVFCodingVariantFocusGroupControlScoreRanges] = None
+    cvfg_missense_variants: Optional[IGVFCodingVariantFocusGroupMissenseScoreRanges] = None

--- a/tests/lib/annotation/test_annotate.py
+++ b/tests/lib/annotation/test_annotate.py
@@ -19,6 +19,13 @@ def test_variant_functional_impact_statement_no_score_ranges(mock_mapped_variant
     assert result is None
 
 
+def test_variant_functional_impact_statement_no_score_range_data(mock_mapped_variant):
+    mock_mapped_variant.variant.score_set.score_ranges["investigator_provided"]["ranges"] = []
+    result = variant_functional_impact_statement(mock_mapped_variant)
+
+    assert result is None
+
+
 def test_variant_functional_impact_statement_no_score(mock_mapped_variant):
     mock_mapped_variant.variant.data = {"score_data": {"score": None}}
     result = variant_functional_impact_statement(mock_mapped_variant)
@@ -68,6 +75,13 @@ def test_variant_pathogenicity_evidence_no_score_ranges_with_thresholds(mock_map
 
 def test_variant_pathogenicity_evidence_with_score_ranges_no_thresholds(mock_mapped_variant):
     mock_mapped_variant.variant.score_set.score_ranges.pop("zeiberg_calibration")
+    result = variant_pathogenicity_evidence(mock_mapped_variant)
+
+    assert result is None
+
+
+def test_variant_pathogenicity_evidence_with_score_ranges_no_threshold_data(mock_mapped_variant):
+    mock_mapped_variant.variant.score_set.score_ranges["zeiberg_calibration"]["ranges"] = []
     result = variant_pathogenicity_evidence(mock_mapped_variant)
 
     assert result is None

--- a/tests/view_models/test_score_range.py
+++ b/tests/view_models/test_score_range.py
@@ -646,6 +646,7 @@ def test_score_ranges_zeiberg_calibration_ranges_boundaries_may_be_adjacent(
     ScoreRangesModel(**valid_data)
 
 
+@pytest.mark.skip("Not applicable currently. Baseline score may be provided on its own.")
 @pytest.mark.parametrize(
     "ScoreRangesModel",
     [


### PR DESCRIPTION
Previously, a score range with a baseline score had validation that required a normal score range. This has been temporarily (or perhaps not temporarily) relaxed. Because of this validation change, an associated change was also needed in annotation library code that checked the validity of incoming ranges for annotation.