### PR TITLE
Remove platform specification from python-base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # python-base
 # Set up shared environment variables
 ################################
-FROM --platform=amd64 python:3.11 AS python-base
+FROM python:3.11 AS python-base
 
     # Poetry
     # https://python-poetry.org/docs/configuration/#using-environment-variables


### PR DESCRIPTION
It's best practice to allow builds to happen on the platform type of the builder. This change is accompanied by a documentation update to the deployment repo that specifies the build platform in the build command, see https://github.com/VariantEffect/mavedb-deployment/pull/20.