### PR TITLE
feat: output VRS digest with post mapped HGVS strings

### DIFF
--- a/src/mavedb/lib/variants.py
+++ b/src/mavedb/lib/variants.py
@@ -1,7 +1,6 @@
 import re
 from typing import Any, Optional
 
-
 HGVS_G_REGEX = re.compile(r"(^|:)g\.")
 HGVS_P_REGEX = re.compile(r"(^|:)p\.")
 
@@ -46,6 +45,23 @@ def get_hgvs_from_post_mapped(post_mapped_vrs: Optional[Any]) -> Optional[str]:
         # raise ValueError(f"Multiple variations found in variant {variant_urn}.")
 
     return variations_hgvs[0]
+
+
+def get_digest_from_post_mapped(post_mapped_vrs: Optional[Any]) -> Optional[str]:
+    """
+    Extract the digest value from a post-mapped VRS object.
+
+    Args:
+        post_mapped_vrs: A post-mapped VRS (Variation Representation Specification) object
+                        that may contain a digest field. Can be None.
+
+    Returns:
+        The digest string if present in the post_mapped_vrs object, otherwise None.
+    """
+    if not post_mapped_vrs:
+        return None
+
+    return post_mapped_vrs.get("digest")  # type: ignore
 
 
 # TODO (https://github.com/VariantEffect/mavedb-api/issues/440) Temporarily, we are using these functions to distinguish

--- a/tests/lib/test_variants.py
+++ b/tests/lib/test_variants.py
@@ -1,14 +1,21 @@
 import pytest
 
-from mavedb.lib.variants import hgvs_from_vrs_allele, get_hgvs_from_post_mapped, is_hgvs_g, is_hgvs_p
-
+from mavedb.lib.variants import (
+    get_digest_from_post_mapped,
+    get_hgvs_from_post_mapped,
+    hgvs_from_vrs_allele,
+    is_hgvs_g,
+    is_hgvs_p,
+)
 from tests.helpers.constants import (
     TEST_HGVS_IDENTIFIER,
     TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS1_X,
     TEST_VALID_POST_MAPPED_VRS_ALLELE_VRS2_X,
-    TEST_VALID_POST_MAPPED_VRS_HAPLOTYPE,
     TEST_VALID_POST_MAPPED_VRS_CIS_PHASED_BLOCK,
+    TEST_VALID_POST_MAPPED_VRS_HAPLOTYPE,
 )
+
+### Tests for hgvs_from_vrs_allele function ###
 
 
 def test_hgvs_from_vrs_allele_vrs_1():
@@ -24,6 +31,9 @@ def test_hgvs_from_vrs_allele_vrs_2():
 def test_hgvs_from_vrs_allele_invalid():
     with pytest.raises(KeyError):
         hgvs_from_vrs_allele({"invalid_key": "invalid_value"})
+
+
+### Tests for get_hgvs_from_post_mapped function ###
 
 
 def test_get_hgvs_from_post_mapped_haplotype():
@@ -59,6 +69,36 @@ def test_get_hgvs_from_post_mapped_invalid_type():
 def test_get_hgvs_from_post_mapped_invalid_structure():
     with pytest.raises(KeyError):
         get_hgvs_from_post_mapped({"invalid_key": "InvalidType"})
+
+
+### Tests for get_digest_from_post_mapped function ###
+
+
+def test_get_digest_from_post_mapped_with_digest():
+    post_mapped_vrs = {"digest": "test_digest_value", "type": "Allele"}
+    result = get_digest_from_post_mapped(post_mapped_vrs)
+    assert result == "test_digest_value"
+
+
+def test_get_digest_from_post_mapped_without_digest():
+    post_mapped_vrs = {"type": "Allele", "other_field": "value"}
+
+    result = get_digest_from_post_mapped(post_mapped_vrs)
+
+    assert result is None
+
+
+def test_get_digest_from_post_mapped_none_input():
+    result = get_digest_from_post_mapped(None)
+    assert result is None
+
+
+def test_get_digest_from_post_mapped_empty_dict():
+    result = get_digest_from_post_mapped({})
+    assert result is None
+
+
+### Tests for is_hgvs_g and is_hgvs_p functions ###
 
 
 @pytest.mark.parametrize(

--- a/tests/routers/test_score_set.py
+++ b/tests/routers/test_score_set.py
@@ -2738,6 +2738,7 @@ def test_download_variants_data_file(
             "hgvs_pro",
             "mavedb.post_mapped_hgvs_g",
             "mavedb.post_mapped_hgvs_p",
+            "mavedb.post_mapped_vrs_digest",
             "scores.score",
         ]
     )
@@ -2862,16 +2863,7 @@ def test_download_scores_and_counts_file(session, data_provider, client, setup_r
     download_scores_and_counts_csv = download_scores_and_counts_csv_response.text
     reader = csv.DictReader(StringIO(download_scores_and_counts_csv))
     assert sorted(reader.fieldnames) == sorted(
-        [
-            "accession",
-            "hgvs_nt",
-            "hgvs_pro",
-            "scores.score",
-            "scores.s_0",
-            "scores.s_1",
-            "counts.c_0",
-            "counts.c_1"
-        ]
+        ["accession", "hgvs_nt", "hgvs_pro", "scores.score", "scores.s_0", "scores.s_1", "counts.c_0", "counts.c_1"]
     )
 
 
@@ -2885,7 +2877,7 @@ def test_download_scores_and_counts_file(session, data_provider, client, setup_r
     ids=["without_post_mapped_vrs", "with_post_mapped_hgvs_g", "with_post_mapped_hgvs_p"],
 )
 def test_download_scores_counts_and_post_mapped_variants_file(
-        session, data_provider, client, setup_router_db, data_files, mapped_variant, has_hgvs_g, has_hgvs_p
+    session, data_provider, client, setup_router_db, data_files, mapped_variant, has_hgvs_g, has_hgvs_p
 ):
     experiment = create_experiment(client)
     score_set = create_seq_score_set(client, experiment["urn"])
@@ -2912,11 +2904,12 @@ def test_download_scores_counts_and_post_mapped_variants_file(
             "hgvs_pro",
             "mavedb.post_mapped_hgvs_g",
             "mavedb.post_mapped_hgvs_p",
+            "mavedb.post_mapped_vrs_digest",
             "scores.score",
             "scores.s_0",
             "scores.s_1",
             "counts.c_0",
-            "counts.c_1"
+            "counts.c_1",
         ]
     )
 


### PR DESCRIPTION
This pull request adds support for extracting and exporting the VRS digest from post-mapped variant objects. The main changes involve updating the CSV export logic to include the digest, implementing the extraction function, and ensuring robust test coverage.

**VRS Digest Extraction and Export:**

* Added a new function `get_digest_from_post_mapped` in `mavedb.lib.variants` to extract the `digest` field from post-mapped VRS objects.
* Updated `get_score_set_variants_as_csv` and `variant_to_csv_row` in `mavedb.lib.score_sets` to include the `post_mapped_vrs_digest` column in exports when post-mapped HGVS columns are included. [[1]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccR550) [[2]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccR707-R709)

**Testing Improvements:**

* Added a suite of tests for `get_digest_from_post_mapped` to verify correct extraction behavior for various input scenarios in `tests/lib/test_variants.py`.

**Codebase Cleanup and Imports:**

* Cleaned up and reordered imports for clarity and consistency in `mavedb.lib.score_sets` and `mavedb.lib.variants`. [[1]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccL1-R13) [[2]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccR38) [[3]](diffhunk://#diff-1eac3122319c0ba2f5bd5a7c71acaff57774e2f314da68b37a3d1100c696b981L4)
* Updated import statements in `tests/lib/test_variants.py` to include the new function and improve readability. [[1]](diffhunk://#diff-3b6db92a91edadf1bbda08ee973184f992442dafb71321f59550347146d63673L3-R19) [[2]](diffhunk://#diff-3b6db92a91edadf1bbda08ee973184f992442dafb71321f59550347146d63673R36-R38)