### PR TITLE
fix: update point label mappings for pillar project assessment levels

### DIFF
--- a/src/mavedb/scripts/load_pp_style_calibration.py
+++ b/src/mavedb/scripts/load_pp_style_calibration.py
@@ -92,9 +92,9 @@ from mavedb.view_models import acmg_classification, score_calibration
 
 POINT_LABEL_MAPPINGS: Dict[int, str] = {
     8: "Very Strong",
-    7: "Very Strong",
-    6: "Very Strong",
-    5: "Very Strong",
+    7: "Strong",
+    6: "Strong",
+    5: "Strong",
     4: "Strong",
     3: "Moderate+",
     2: "Moderate",


### PR DESCRIPTION
This pull request makes a small but important update to the `POINT_LABEL_MAPPINGS` dictionary in the `load_pp_style_calibration.py` script. The change adjusts the descriptive labels for certain point values to better reflect their intended meaning.

Label mapping update:
* Updated the labels for point values 5, 6, and 7 from "Very Strong" to "Strong" in the `POINT_LABEL_MAPPINGS` dictionary in `load_pp_style_calibration.py`.