### PR TITLE
Re-order ClinGen Variant Submissions

### DIFF
--- a/src/mavedb/lib/exceptions.py
+++ b/src/mavedb/lib/exceptions.py
@@ -186,12 +186,6 @@ class SubmissionEnqueueError(ValueError):
     pass
 
 
-class LinkingEnqueueError(ValueError):
-    """Raised when a linking job fails to be enqueued despite appearing as if it should have been"""
-
-    pass
-
-
 class UniProtIDMappingEnqueueError(Exception):
     """Raised when a UniProt ID mapping job fails to be enqueued despite appearing as if it should have been"""
 

--- a/src/mavedb/worker/jobs.py
+++ b/src/mavedb/worker/jobs.py
@@ -20,18 +20,14 @@ from mavedb.lib.clingen.constants import (
     CLIN_GEN_SUBMISSION_ENABLED,
     DEFAULT_LDH_SUBMISSION_BATCH_SIZE,
     LDH_SUBMISSION_ENDPOINT,
-    LINKED_DATA_RETRY_THRESHOLD,
 )
 from mavedb.lib.clingen.content_constructors import construct_ldh_submission
 from mavedb.lib.clingen.services import (
     ClinGenAlleleRegistryService,
     ClinGenLdhService,
-    clingen_allele_id_from_ldh_variation,
     get_allele_registry_associations,
-    get_clingen_variation,
 )
 from mavedb.lib.exceptions import (
-    LinkingEnqueueError,
     MappingEnqueueError,
     NonexistentMappingReferenceError,
     NonexistentMappingResultsError,
@@ -846,7 +842,6 @@ async def submit_score_set_mappings_to_car(ctx: dict, correlation_id: str, score
     text = "Could not submit mappings to ClinGen Allele Registry for score set %s. Mappings for this score set should be submitted manually."
     try:
         db: Session = ctx["db"]
-        redis: ArqRedis = ctx["redis"]
         score_set = db.scalars(select(ScoreSet).where(ScoreSet.id == score_set_id)).one()
 
         logging_context = setup_job_state(ctx, None, score_set.urn, correlation_id)
@@ -968,38 +963,8 @@ async def submit_score_set_mappings_to_car(ctx: dict, correlation_id: str, score
 
         return {"success": False, "retried": False, "enqueued_job": None}
 
-    new_job_id = None
-    try:
-        new_job = await redis.enqueue_job(
-            "submit_score_set_mappings_to_ldh",
-            correlation_id,
-            score_set.id,
-        )
-
-        if new_job:
-            new_job_id = new_job.job_id
-
-            logging_context["submit_clingen_ldh_variants_job_id"] = new_job_id
-            logger.info(msg="Queued a new ClinGen submission job.", extra=logging_context)
-
-        else:
-            raise SubmissionEnqueueError()
-
-    except Exception as e:
-        send_slack_error(e)
-        send_slack_message(
-            f"Could not submit mappings to LDH for score set {score_set.urn}. Mappings for this score set should be submitted manually."
-        )
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.error(
-            msg="Mapped variant ClinGen submission encountered an unexpected error while attempting to enqueue a submission job. This job will not be retried.",
-            extra=logging_context,
-        )
-
-        return {"success": False, "retried": False, "enqueued_job": new_job_id}
-
     ctx["state"][ctx["job_id"]] = logging_context.copy()
-    return {"success": True, "retried": False, "enqueued_job": new_job_id}
+    return {"success": True, "retried": False, "enqueued_job": None}
 
 
 async def submit_score_set_mappings_to_ldh(ctx: dict, correlation_id: str, score_set_id: int):
@@ -1010,7 +975,6 @@ async def submit_score_set_mappings_to_ldh(ctx: dict, correlation_id: str, score
     )
     try:
         db: Session = ctx["db"]
-        redis: ArqRedis = ctx["redis"]
         score_set = db.scalars(select(ScoreSet).where(ScoreSet.id == score_set_id)).one()
 
         logging_context = setup_job_state(ctx, None, score_set.urn, correlation_id)
@@ -1070,16 +1034,14 @@ async def submit_score_set_mappings_to_ldh(ctx: dict, correlation_id: str, score
 
         variant_content = []
         for variant, mapped_variant in variant_objects:
-            variation = get_hgvs_from_post_mapped(mapped_variant.post_mapped)
-
-            if not variation:
+            if not mapped_variant.hgvs_assay_level:
                 logger.warning(
-                    msg=f"Could not construct a valid HGVS string for mapped variant {mapped_variant.id}. Skipping submission of this variant.",
+                    msg=f"No valid assay level HGVS string for mapped variant {mapped_variant.id}. Skipping submission of this variant.",
                     extra=logging_context,
                 )
                 continue
 
-            variant_content.append((variation, variant, mapped_variant))
+            variant_content.append((mapped_variant.hgvs_assay_level, variant, mapped_variant))
 
         submission_content = construct_ldh_submission(variant_content)
 
@@ -1128,314 +1090,7 @@ async def submit_score_set_mappings_to_ldh(ctx: dict, correlation_id: str, score
 
         return {"success": False, "retried": False, "enqueued_job": None}
 
-    new_job_id = None
-    try:
-        new_job = await redis.enqueue_job(
-            "link_clingen_variants",
-            correlation_id,
-            score_set.id,
-            1,
-            _defer_by=timedelta(seconds=LINKING_BACKOFF_IN_SECONDS),
-        )
-
-        if new_job:
-            new_job_id = new_job.job_id
-
-            logging_context["link_clingen_variants_job_id"] = new_job_id
-            logger.info(msg="Queued a new ClinGen linking job.", extra=logging_context)
-
-        else:
-            raise LinkingEnqueueError()
-
-    except Exception as e:
-        send_slack_error(e)
-        send_slack_message(text=text % score_set.urn)
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.error(
-            msg="LDH mapped resource submission encountered an unexpected error while attempting to enqueue a linking job. This job will not be retried.",
-            extra=logging_context,
-        )
-
-        return {"success": False, "retried": False, "enqueued_job": new_job_id}
-
-    return {"success": True, "retried": False, "enqueued_job": new_job_id}
-
-
-def do_clingen_fetch(variant_urns):
-    return [(variant_urn, get_clingen_variation(variant_urn)) for variant_urn in variant_urns]
-
-
-async def link_clingen_variants(ctx: dict, correlation_id: str, score_set_id: int, attempt: int) -> dict:
-    logging_context = {}
-    score_set = None
-    text = "Could not link mappings to LDH for score set %s. Mappings for this score set should be linked manually."
-    try:
-        db: Session = ctx["db"]
-        redis: ArqRedis = ctx["redis"]
-        score_set = db.scalars(select(ScoreSet).where(ScoreSet.id == score_set_id)).one()
-
-        logging_context = setup_job_state(ctx, None, score_set.urn, correlation_id)
-        logging_context["linkage_retry_threshold"] = LINKED_DATA_RETRY_THRESHOLD
-        logging_context["attempt"] = attempt
-        logging_context["max_attempts"] = BACKOFF_LIMIT
-        logger.info(msg="Started LDH mapped resource linkage", extra=logging_context)
-
-        submission_urn = score_set.urn
-        assert submission_urn, "A valid URN is needed to link LDH objects for this score set."
-
-        logging_context["current_ldh_linking_resource"] = submission_urn
-        logger.debug(msg="Fetched score set metadata for ldh mapped resource linkage.", extra=logging_context)
-
-    except Exception as e:
-        send_slack_error(e)
-        if score_set:
-            send_slack_message(text=text % score_set.urn)
-        else:
-            send_slack_message(text=text % score_set_id)
-
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.error(
-            msg="LDH mapped resource linkage encountered an unexpected error during setup. This job will not be retried.",
-            extra=logging_context,
-        )
-
-        return {"success": False, "retried": False, "enqueued_job": None}
-
-    try:
-        variant_urns = db.scalars(
-            select(Variant.urn)
-            .join(MappedVariant)
-            .join(ScoreSet)
-            .where(
-                ScoreSet.urn == score_set.urn, MappedVariant.current.is_(True), MappedVariant.post_mapped.is_not(None)
-            )
-        ).all()
-        num_variant_urns = len(variant_urns)
-
-        logging_context["variants_to_link_ldh"] = num_variant_urns
-
-        if not variant_urns:
-            logger.warning(
-                msg="No current mapped variants with post mapped metadata were found for this score set. Skipping LDH linkage (nothing to do). A gnomAD linkage job will not be enqueued, as no variants will have a CAID.",
-                extra=logging_context,
-            )
-
-            return {"success": True, "retried": False, "enqueued_job": None}
-
-        logger.info(
-            msg="Found current mapped variants with post mapped metadata for this score set. Attempting to link them to LDH submissions.",
-            extra=logging_context,
-        )
-
-    except Exception as e:
-        send_slack_error(e)
-        send_slack_message(text=text % score_set.urn)
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.error(
-            msg="LDH mapped resource linkage encountered an unexpected error while attempting to build linkage urn list. This job will not be retried.",
-            extra=logging_context,
-        )
-
-        return {"success": False, "retried": False, "enqueued_job": None}
-
-    try:
-        logger.info(msg="Attempting to link mapped variants to LDH submissions.", extra=logging_context)
-
-        # TODO#372: Non-nullable variant urns.
-        blocking = functools.partial(
-            do_clingen_fetch,
-            variant_urns,  # type: ignore
-        )
-        loop = asyncio.get_running_loop()
-        linked_data = await loop.run_in_executor(ctx["pool"], blocking)
-
-    except Exception as e:
-        send_slack_error(e)
-        send_slack_message(text=text % score_set.urn)
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.error(
-            msg="LDH mapped resource linkage encountered an unexpected error while attempting to link LDH submissions. This job will not be retried.",
-            extra=logging_context,
-        )
-
-        return {"success": False, "retried": False, "enqueued_job": None}
-
-    try:
-        linked_allele_ids = [
-            (variant_urn, clingen_allele_id_from_ldh_variation(clingen_variation))
-            for variant_urn, clingen_variation in linked_data
-        ]
-
-        linkage_failures = []
-        for variant_urn, ldh_variation in linked_allele_ids:
-            # XXX: Should we unlink variation if it is not found? Does this constitute a failure?
-            if not ldh_variation:
-                logger.warning(
-                    msg=f"Failed to link mapped variant {variant_urn} to LDH submission. No LDH variation found.",
-                    extra=logging_context,
-                )
-                linkage_failures.append(variant_urn)
-                continue
-
-            mapped_variant = db.scalars(
-                select(MappedVariant).join(Variant).where(Variant.urn == variant_urn, MappedVariant.current.is_(True))
-            ).one_or_none()
-
-            if not mapped_variant:
-                logger.warning(
-                    msg=f"Failed to link mapped variant {variant_urn} to LDH submission. No mapped variant found.",
-                    extra=logging_context,
-                )
-                linkage_failures.append(variant_urn)
-                continue
-
-            mapped_variant.clingen_allele_id = ldh_variation
-            db.add(mapped_variant)
-
-        db.commit()
-
-    except Exception as e:
-        db.rollback()
-
-        send_slack_error(e)
-        send_slack_message(text=text % score_set.urn)
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.error(
-            msg="LDH mapped resource linkage encountered an unexpected error while attempting to link LDH submissions. This job will not be retried.",
-            extra=logging_context,
-        )
-
-        return {"success": False, "retried": False, "enqueued_job": None}
-
-    try:
-        num_linkage_failures = len(linkage_failures)
-        ratio_failed_linking = round(num_linkage_failures / num_variant_urns, 3)
-        logging_context["linkage_failure_rate"] = ratio_failed_linking
-        logging_context["linkage_failures"] = num_linkage_failures
-        logging_context["linkage_successes"] = num_variant_urns - num_linkage_failures
-
-        assert (
-            len(linked_allele_ids) == num_variant_urns
-        ), f"{num_variant_urns - len(linked_allele_ids)} appear to not have been attempted to be linked."
-
-        job_succeeded = False
-        if not linkage_failures:
-            logger.info(
-                msg="Successfully linked all mapped variants to LDH submissions.",
-                extra=logging_context,
-            )
-
-            job_succeeded = True
-
-        elif ratio_failed_linking < LINKED_DATA_RETRY_THRESHOLD:
-            logger.warning(
-                msg="Linkage failures exist, but did not exceed the retry threshold.",
-                extra=logging_context,
-            )
-            send_slack_message(
-                text=f"Failed to link {len(linkage_failures)} mapped variants to LDH submissions for score set {score_set.urn}."
-                f"The retry threshold was not exceeded and this job will not be retried. URNs failed to link: {', '.join(linkage_failures)}."
-            )
-
-            job_succeeded = True
-
-    except Exception as e:
-        send_slack_error(e)
-        send_slack_message(text=text % score_set.urn)
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.error(
-            msg="LDH mapped resource linkage encountered an unexpected error while attempting to finalize linkage. This job will not be retried.",
-            extra=logging_context,
-        )
-
-        return {"success": False, "retried": False, "enqueued_job": None}
-
-    if job_succeeded:
-        gnomad_linking_job_id = None
-        try:
-            new_job = await redis.enqueue_job(
-                "link_gnomad_variants",
-                correlation_id,
-                score_set.id,
-            )
-
-            if new_job:
-                gnomad_linking_job_id = new_job.job_id
-
-                logging_context["link_gnomad_variants_job_id"] = gnomad_linking_job_id
-                logger.info(msg="Queued a new gnomAD linking job.", extra=logging_context)
-
-            else:
-                raise LinkingEnqueueError()
-
-        except Exception as e:
-            job_succeeded = False
-
-            send_slack_error(e)
-            send_slack_message(text=text % score_set.urn)
-            logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-            logger.error(
-                msg="LDH mapped resource linkage encountered an unexpected error while attempting to enqueue a gnomAD linking job. GnomAD variants should be linked manually for this score set. This job will not be retried.",
-                extra=logging_context,
-            )
-        finally:
-            return {"success": job_succeeded, "retried": False, "enqueued_job": gnomad_linking_job_id}
-
-    # If we reach this point, we should consider the job failed (there were failures which exceeded our retry threshold).
-    new_job_id = None
-    max_retries_exceeded = None
-    try:
-        new_job_id, max_retries_exceeded, backoff_time = await enqueue_job_with_backoff(
-            ctx["redis"], "variant_mapper_manager", attempt, LINKING_BACKOFF_IN_SECONDS, correlation_id
-        )
-
-        logging_context["backoff_limit_exceeded"] = max_retries_exceeded
-        logging_context["backoff_deferred_in_seconds"] = backoff_time
-        logging_context["backoff_job_id"] = new_job_id
-
-    except Exception as e:
-        send_slack_error(e)
-        send_slack_message(text=text % score_set.urn)
-        logging_context = {**logging_context, **format_raised_exception_info_as_dict(e)}
-        logger.critical(
-            msg="LDH mapped resource linkage encountered an unexpected error while attempting to retry a failed linkage job. This job will not be retried.",
-            extra=logging_context,
-        )
-    else:
-        if new_job_id and not max_retries_exceeded:
-            logger.info(
-                msg="After a failure condition while linking mapped variants to LDH submissions, another linkage job was queued.",
-                extra=logging_context,
-            )
-            send_slack_message(
-                text=f"Failed to link {len(linkage_failures)} ({ratio_failed_linking * 100}% of total mapped variants for {score_set.urn})."
-                f"This job was successfully retried. This was attempt {attempt}. Retry will occur in {backoff_time} seconds. URNs failed to link: {', '.join(linkage_failures)}."
-            )
-        elif new_job_id is None and not max_retries_exceeded:
-            logger.error(
-                msg="After a failure condition while linking mapped variants to LDH submissions, another linkage job was unable to be queued.",
-                extra=logging_context,
-            )
-            send_slack_message(
-                text=f"Failed to link {len(linkage_failures)} ({ratio_failed_linking} of total mapped variants for {score_set.urn})."
-                f"This job could not be retried due to an unexpected issue while attempting to enqueue another linkage job. This was attempt {attempt}. URNs failed to link: {', '.join(linkage_failures)}."
-            )
-        else:
-            logger.error(
-                msg="After a failure condition while linking mapped variants to LDH submissions, the maximum retries for this job were exceeded. The reamining linkage failures will not be retried.",
-                extra=logging_context,
-            )
-            send_slack_message(
-                text=f"Failed to link {len(linkage_failures)} ({ratio_failed_linking} of total mapped variants for {score_set.urn})."
-                f"The retry threshold was exceeded and this job will not be retried. URNs failed to link: {', '.join(linkage_failures)}."
-            )
-
-    finally:
-        return {
-            "success": False,
-            "retried": (not max_retries_exceeded and new_job_id is not None),
-            "enqueued_job": new_job_id,
-        }
+    return {"success": True, "retried": False, "enqueued_job": None}
 
 
 ########################################################################################################

--- a/src/mavedb/worker/settings.py
+++ b/src/mavedb/worker/settings.py
@@ -11,16 +11,15 @@ from mavedb.db.session import SessionLocal
 from mavedb.lib.logging.canonical import log_job
 from mavedb.worker.jobs import (
     create_variants_for_score_set,
+    link_gnomad_variants,
     map_variants_for_score_set,
-    variant_mapper_manager,
+    poll_uniprot_mapping_jobs_for_score_set,
     refresh_materialized_views,
     refresh_published_variants_view,
-    submit_score_set_mappings_to_ldh,
-    link_clingen_variants,
-    poll_uniprot_mapping_jobs_for_score_set,
-    submit_uniprot_mapping_jobs_for_score_set,
-    link_gnomad_variants,
     submit_score_set_mappings_to_car,
+    submit_score_set_mappings_to_ldh,
+    submit_uniprot_mapping_jobs_for_score_set,
+    variant_mapper_manager,
 )
 
 # ARQ requires at least one task on startup.
@@ -30,7 +29,6 @@ BACKGROUND_FUNCTIONS: list[Callable] = [
     map_variants_for_score_set,
     refresh_published_variants_view,
     submit_score_set_mappings_to_ldh,
-    link_clingen_variants,
     poll_uniprot_mapping_jobs_for_score_set,
     submit_uniprot_mapping_jobs_for_score_set,
     link_gnomad_variants,

--- a/tests/routers/test_collections.py
+++ b/tests/routers/test_collections.py
@@ -2,10 +2,10 @@
 
 import re
 from copy import deepcopy
-from unittest.mock import patch
 
 import jsonschema
 import pytest
+from sqlalchemy import select
 
 arq = pytest.importorskip("arq")
 cdot = pytest.importorskip("cdot")
@@ -13,13 +13,13 @@ fastapi = pytest.importorskip("fastapi")
 
 from mavedb.lib.validation.urn_re import MAVEDB_COLLECTION_URN_RE
 from mavedb.models.enums.contribution_role import ContributionRole
+from mavedb.models.score_set import ScoreSet as ScoreSetDbModel
 from mavedb.view_models.collection import Collection
-
 from tests.helpers.constants import (
     EXTRA_USER,
-    TEST_USER,
     TEST_COLLECTION,
     TEST_COLLECTION_RESPONSE,
+    TEST_USER,
 )
 from tests.helpers.dependency_overrider import DependencyOverrider
 from tests.helpers.util.collection import create_collection
@@ -235,9 +235,10 @@ def test_admin_can_add_experiment_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
     client.post(f"/api/v1/collections/{collection['urn']}/admins", json={"orcid_id": EXTRA_USER["username"]})
@@ -293,9 +294,10 @@ def test_editor_can_add_experiment_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
     client.post(f"/api/v1/collections/{collection['urn']}/editors", json={"orcid_id": EXTRA_USER["username"]})
@@ -345,9 +347,10 @@ def test_viewer_cannot_add_experiment_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
     client.post(f"/api/v1/collections/{collection['urn']}/viewers", json={"orcid_id": EXTRA_USER["username"]})
@@ -372,9 +375,10 @@ def test_unauthorized_user_cannot_add_experiment_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
 
@@ -397,9 +401,10 @@ def test_anonymous_cannot_add_experiment_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
 
@@ -422,9 +427,10 @@ def test_admin_can_add_score_set_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
     client.post(f"/api/v1/collections/{collection['urn']}/admins", json={"orcid_id": EXTRA_USER["username"]})
@@ -479,9 +485,10 @@ def test_editor_can_add_score_set_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
     client.post(f"/api/v1/collections/{collection['urn']}/editors", json={"orcid_id": EXTRA_USER["username"]})
@@ -530,9 +537,10 @@ def test_viewer_cannot_add_score_set_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
     client.post(f"/api/v1/collections/{collection['urn']}/viewers", json={"orcid_id": EXTRA_USER["username"]})
@@ -556,9 +564,10 @@ def test_unauthorized_user_cannot_add_score_set_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
 
@@ -580,9 +589,10 @@ def test_anonymous_cannot_add_score_set_to_collection(
         client, session, data_provider, unpublished_score_set, data_files / "scores.csv"
     )
 
-    with patch.object(arq.ArqRedis, "enqueue_job", return_value=None) as worker_queue:
-        score_set = publish_score_set(client, unpublished_score_set["urn"])
-        worker_queue.assert_called_once()
+    score_set_id = session.scalars(
+        select(ScoreSetDbModel.id).where(ScoreSetDbModel.urn == unpublished_score_set["urn"])
+    ).one()
+    score_set = publish_score_set(client, unpublished_score_set["urn"], score_set_id)
 
     collection = create_collection(client)
 


### PR DESCRIPTION
This pull request refactors the job submission and error handling logic for mapping variant data and submitting it to external services (ClinGen Allele Registry and LDH). These changes necessitated a rework of how publication testing is handled to reduce duplication.

**Error handling and exception cleanup:**
* Removed the unused `LinkingEnqueueError` exception class from `src/mavedb/lib/exceptions.py` and its imports, simplifying the exception hierarchy. [[1]](diffhunk://#diff-5a390f9ae9d4cd22ede1195e42b5130ad02e4ee5cde5c65b0be8d9fba1695ba0L189-L194) [[2]](diffhunk://#diff-23dc1425b054f2fa3a79e249538653d5e66f440dfea897cc34a4c0d8d00f1e4fL23-L34)

**Job submission and queue logic improvements:**
* Refactored the job enqueuing logic in `publish_score_set` to use more descriptive variable names (`refresh_published_variants_job`, `submit_to_ldh_job`) and improved logging context keys for better traceability.
* Removed unnecessary redis job enqueuing for LDH submission from the CAR submission job, streamlining the workflow and eliminating unnecessary job chaining.
* Invoked the LDH submission job on score set publication, rather than after CAR submission.
* Construct `hgvs_assay_level` after mapping completes, so it is available directly for the CAR and LDH submission jobs.
* Removed the unnecessary `link_clingen_variants` job, as this linkage is handled directly by CAR submission.

**HGVS string handling and logging enhancements:**
* Changed the mapped variant selection to use the new `hgvs_assay_level` field instead of `post_mapped`, and added logging for variants missing this field, improving error visibility and data integrity. [[1]](diffhunk://#diff-23dc1425b054f2fa3a79e249538653d5e66f440dfea897cc34a4c0d8d00f1e4fR503) [[2]](diffhunk://#diff-23dc1425b054f2fa3a79e249538653d5e66f440dfea897cc34a4c0d8d00f1e4fL877-R916)
* Updated error messages and logging to consistently refer to CAR (ClinGen Allele Registry) instead of LDH where appropriate, clarifying the target service and improving log accuracy. [[1]](diffhunk://#diff-23dc1425b054f2fa3a79e249538653d5e66f440dfea897cc34a4c0d8d00f1e4fL934-R937) [[2]](diffhunk://#diff-23dc1425b054f2fa3a79e249538653d5e66f440dfea897cc34a4c0d8d00f1e4fL963-R967)

**Imports and code cleanup:**
* Cleaned up imports in `src/mavedb/worker/jobs.py`, removing unused functions and exception imports, and adding `func` for SQL operations. [[1]](diffhunk://#diff-23dc1425b054f2fa3a79e249538653d5e66f440dfea897cc34a4c0d8d00f1e4fL12-R12) [[2]](diffhunk://#diff-23dc1425b054f2fa3a79e249538653d5e66f440dfea897cc34a4c0d8d00f1e4fL23-L34)