### PR TITLE
feat: add ClinGen namespace to CSV export functionality

### DIFF
--- a/src/mavedb/lib/score_sets.py
+++ b/src/mavedb/lib/score_sets.py
@@ -502,7 +502,7 @@ def find_publish_or_private_superseded_score_set_tail(
 def get_score_set_variants_as_csv(
     db: Session,
     score_set: ScoreSet,
-    namespaces: List[Literal["scores", "counts", "vep", "gnomad"]],
+    namespaces: List[Literal["scores", "counts", "vep", "gnomad", "clingen"]],
     namespaced: Optional[bool] = None,
     start: Optional[int] = None,
     limit: Optional[int] = None,
@@ -519,8 +519,8 @@ def get_score_set_variants_as_csv(
         The database session to use.
     score_set : ScoreSet
         The score set to get the variants from.
-    namespaces : List[Literal["scores", "counts", "vep", "gnomad"]]
-        The namespaces for data. Now there are only scores, counts, VEP, and gnomAD. ClinVar will be added in the future.
+    namespaces : List[Literal["scores", "counts", "vep", "gnomad", "clingen"]]
+        The namespaces for data. Now there are only scores, counts, VEP, gnomAD, and ClinGen. ClinVar will be added in the future.
     namespaced: Optional[bool] = None
         Whether namespace the columns or not.
     start : int, optional
@@ -569,6 +569,8 @@ def get_score_set_variants_as_csv(
         namespaced_score_set_columns["vep"].append("vep_functional_consequence")
     if "gnomad" in namespaced_score_set_columns:
         namespaced_score_set_columns["gnomad"].append("gnomad_af")
+    if "clingen" in namespaced_score_set_columns:
+        namespaced_score_set_columns["clingen"].append("clingen_allele_id")
     variants: Sequence[Variant] = []
     mappings: Optional[list[Optional[MappedVariant]]] = None
     gnomad_data: Optional[list[Optional[GnomADVariant]]] = None
@@ -840,6 +842,15 @@ def variant_to_csv_row(
             else:
                 value = na_rep
         key = f"gnomad.{column_key}" if namespaced else column_key
+        row[key] = value
+    for column_key in columns.get("clingen", []):
+        if column_key == "clingen_allele_id":
+            clingen_allele_id = mapping.clingen_allele_id if mapping else None
+            if clingen_allele_id is not None:
+                value = str(clingen_allele_id)
+            else:
+                value = na_rep
+        key = f"clingen.{column_key}" if namespaced else column_key
         row[key] = value
     return row
 

--- a/src/mavedb/routers/score_sets.py
+++ b/src/mavedb/routers/score_sets.py
@@ -706,8 +706,8 @@ def get_score_set_variants_csv(
     urn: str,
     start: int = Query(default=None, description="Start index for pagination"),
     limit: int = Query(default=None, description="Maximum number of variants to return"),
-    namespaces: List[Literal["scores", "counts", "vep", "gnomad"]] = Query(
-        default=["scores"], description="One or more data types to include: scores, counts, clinVar, gnomAD, VEP"
+    namespaces: List[Literal["scores", "counts", "vep", "gnomad", "clingen"]] = Query(
+        default=["scores"], description="One or more data types to include: scores, counts, ClinGen, gnomAD, VEP"
     ),
     drop_na_columns: Optional[bool] = None,
     include_custom_columns: Optional[bool] = None,
@@ -732,7 +732,7 @@ def get_score_set_variants_csv(
         The index to start from. If None, starts from the beginning.
     limit : Optional[int]
         The maximum number of variants to return. If None, returns all variants.
-    namespaces: List[Literal["scores", "counts", "vep", "gnomad"]]
+    namespaces: List[Literal["scores", "counts", "vep", "gnomad", "clingen"]]
         The namespaces of all columns except for accession, hgvs_nt, hgvs_pro, and hgvs_splice.
         We may add ClinVar in the future.
     drop_na_columns : bool, optional


### PR DESCRIPTION
This pull request adds support for exporting ClinGen allele IDs in the variant data export endpoint, alongside improvements to the handling of namespaces in both the backend and API documentation. It also includes new tests to ensure that the ClinGen, VEP, and gnomAD namespaces are correctly exported in the CSV variant data.

**API and Backend Enhancements:**

* Added `"clingen"` as a supported namespace for variant data export in both the backend logic (`score_sets.py`) and the API endpoint (`score_sets.py`). [[1]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccL505-R505) [[2]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccL522-R523) [[3]](diffhunk://#diff-6116c1df8273d3b85cb87b98c7c34378c0b7d110fb3703242f035de6ab1a7822L709-R710) [[4]](diffhunk://#diff-6116c1df8273d3b85cb87b98c7c34378c0b7d110fb3703242f035de6ab1a7822L735-R735)
* Updated the CSV export logic to include the `clingen_allele_id` column when the `"clingen"` namespace is requested. [[1]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccR572-R573) [[2]](diffhunk://#diff-c8ce20871d6a759b4536ff3044da17c02261be8fd68f0499be9a60697f8c3dccR846-R854)

**Testing Improvements:**

* Added tests for the export of VEP, ClinGen, and gnomAD namespaces in the variant data endpoint, verifying that the correct columns and values are present in the exported CSVs.