### PR TITLE
docs: enhance score set create/patch endpoints with detailed OpenAPI schema for file uploads

### DIFF
--- a/src/mavedb/routers/score_sets.py
+++ b/src/mavedb/routers/score_sets.py
@@ -1704,21 +1704,22 @@ async def create_score_set(
                                 "description": "CSV file containing variant scores. This file is required, and should have at least one score column.",
                             },
                             "counts_file": {
-                                "type": "string | null",
+                                "type": "string",
                                 "format": "binary",
                                 "description": "CSV file containing variant counts. If provided, this file should have the same index and variant columns as the scores file.",
                             },
                             "score_columns_metadata": {
-                                "type": "string | null",
+                                "type": "string",
                                 "format": "binary",
                                 "description": "JSON file containing metadata for score columns. If provided, this file should have metadata for one or more score columns in the scores file. This JSON file should provide a dictionary mapping column names to metadata objects. Metadata objects should follow the DatasetColumnMetadata schema: `{'description': string, 'details': string}`.",
                             },
                             "count_columns_metadata": {
-                                "type": "string | null",
+                                "type": "string",
                                 "format": "binary",
                                 "description": "JSON file containing metadata for count columns. If provided, this file should have metadata for one or more count columns in the counts file. This JSON file should provide a dictionary mapping column names to metadata objects. Metadata objects should follow the DatasetColumnMetadata schema: `{'description': string, 'details': string}`.",
                             },
                         },
+                        "required": ["scores_file"],
                     }
                 },
             },
@@ -1806,22 +1807,22 @@ async def upload_score_set_variant_data(
                         "properties": {
                             **score_set.ScoreSetUpdateAllOptional.model_json_schema(by_alias=False)["properties"],
                             "scores_file": {
-                                "type": "string | null",
+                                "type": "string",
                                 "format": "binary",
                                 "description": "CSV file containing variant scores. If provided, this file should have at least one score column.",
                             },
                             "counts_file": {
-                                "type": "string | null",
+                                "type": "string",
                                 "format": "binary",
                                 "description": "CSV file containing variant counts. If provided, this file should have the same index and variant columns as the scores file.",
                             },
                             "score_columns_metadata": {
-                                "type": "string | null",
+                                "type": "string",
                                 "format": "binary",
                                 "description": "JSON file containing metadata for score columns. If provided, this file should have metadata for one or more score columns in the scores file. This JSON file should provide a dictionary mapping column names to metadata objects. Metadata objects should follow the DatasetColumnMetadata schema: `{'description': string, 'details': string}`.",
                             },
                             "count_columns_metadata": {
-                                "type": "string | null",
+                                "type": "string",
                                 "format": "binary",
                                 "description": "JSON file containing metadata for count columns. If provided, this file should have metadata for one or more count columns in the counts file. This JSON file should provide a dictionary mapping column names to metadata objects. Metadata objects should follow the DatasetColumnMetadata schema: `{'description': string, 'details': string}`.",
                             },


### PR DESCRIPTION
This pull request enhances the OpenAPI documentation for the score set upload and patch endpoints by explicitly defining the multipart form data schema for file uploads and associated metadata. These changes improve API usability and clarity for clients interacting with these endpoints.

**OpenAPI schema improvements for file upload endpoints:**

* Added detailed `openapi_extra` definitions to the `create_score_set` endpoint, specifying the multipart form data schema for required and optional files (`scores_file`, `counts_file`, `score_columns_metadata`, `count_columns_metadata`), including descriptions and data types.
* Enhanced the `upload_score_set_variant_data` endpoint with an explicit multipart form schema in `openapi_extra`, including all updateable score set properties and optional file uploads, improving the OpenAPI documentation for clients.