### PR TITLE
Return default alphafold version when parsing or request for XML fails

### DIFF
--- a/src/mavedb/routers/alphafold.py
+++ b/src/mavedb/routers/alphafold.py
@@ -2,7 +2,7 @@ import re
 import xml.etree.ElementTree as ET
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from mavedb.lib.logging.logged_route import LoggedRoute
 

--- a/src/mavedb/routers/alphafold.py
+++ b/src/mavedb/routers/alphafold.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, HTTPException
-import httpx
-import xml.etree.ElementTree as ET
 import re
+import xml.etree.ElementTree as ET
+
+import httpx
+from fastapi import APIRouter, HTTPException
 
 from mavedb.lib.logging.logged_route import LoggedRoute
 
@@ -14,15 +15,18 @@ router = APIRouter(
     route_class=LoggedRoute,
 )
 
+
 @router.get("/alphafold-files/version")
 async def proxy_alphafold_index():
     """
     Proxy the AlphaFold files index (XML document).
     """
+    DEFAULT_RESPONSE = {"version": "v6"}
+
     async with httpx.AsyncClient(follow_redirects=True, timeout=30) as client:
         resp = await client.get(ALPHAFOLD_BASE, headers={"Accept": "application/xml"})
     if resp.status_code != 200:
-        raise HTTPException(status_code=resp.status_code, detail="Upstream error fetching AlphaFold files index")
+        return DEFAULT_RESPONSE
 
     # parse XML response
     try:
@@ -42,9 +46,9 @@ async def proxy_alphafold_index():
 
         match = re.search(r"model_(v\d+)\.pdb$", next_marker, re.IGNORECASE)
         if not match:
-            raise HTTPException(status_code=500, detail="Malformed AlphaFold PDB ID in XML")
+            return DEFAULT_RESPONSE
         version = match.group(1)
         return {"version": version.lower()}
 
-    except ET.ParseError as e:
-        raise HTTPException(status_code=502, detail=f"Failed to parse upstream XML: {e}")
+    except Exception:
+        return DEFAULT_RESPONSE


### PR DESCRIPTION
The `GET /alphafold-files/version` endpoint will be deprecated after PR varianteffect/mavedb-ui#631 is merged and deployed. In the meantime, to keep the protein visualizations functional, updating the endpoint to return v6 as a default version number since requests currently fail otherwise.

