### PR TITLE
feat: Add Zenodo changelog

### DIFF
--- a/src/mavedb/scripts/export_public_data.py
+++ b/src/mavedb/scripts/export_public_data.py
@@ -11,6 +11,10 @@ See `src/mavedb/scripts/resources/README.md` for a full description of the archi
 
 Unpublished data and data sets licensed other than under the Creative Commons Zero license are not included in the dump,
 and user details are limited to ORCID IDs and names of contributors to published data sets.
+
+RELEASING A NEW VERSION: Before publishing a new version of this archive to Zenodo, add an entry describing what
+changed to `src/mavedb/scripts/resources/CHANGELOG.md` (it is bundled into the archive). The full release procedure
+is documented in `deployment/docs/zenodo-release.md`.
 """
 
 import json
@@ -129,10 +133,11 @@ def export_public_data(db: Session):
         # Write metadata for all data sets to a single JSON file.
         zipfile.writestr("main.json", json.dumps(jsonable_encoder(json_data)))
 
-        # Copy the CC0 license and README.
+        # Copy the CC0 license, README, and changelog.
         resources_dir = os.path.join(os.path.dirname(__file__), "resources")
         zipfile.write(os.path.join(resources_dir, "CC0_license.txt"), "LICENSE.txt")
         zipfile.write(os.path.join(resources_dir, "README.md"), "README.md")
+        zipfile.write(os.path.join(resources_dir, "CHANGELOG.md"), "CHANGELOG.md")
 
         # Write score and count files for each score set.
         num_score_sets = len(score_set_ids)

--- a/src/mavedb/scripts/resources/CHANGELOG.md
+++ b/src/mavedb/scripts/resources/CHANGELOG.md
@@ -1,0 +1,62 @@
+# MaveDB Public Data Dump — Changelog
+
+This file records what changed between versions of the MaveDB bulk data archive
+published on [Zenodo](https://doi.org/10.5281/zenodo.11201736). It ships inside
+every archive so the version you downloaded always carries its own history.
+
+Versions are the Zenodo archive versions (v1, v2, …), not MaveDB API or website
+release numbers. The `asOf` timestamp in `main.json` records the exact moment a
+given archive was generated.
+
+---
+
+## [5] — 2026-06-25
+
+Version 5 is the first version tracked in this changelog. Versions 1–4 contained
+metadata (`main.json`) plus per-score-set score and count CSVs; they predate this
+file and are not itemized here. Version 5 adds variant-mapping and annotation
+outputs derived from the MaveDB variant mapping pipeline.
+
+### Added
+
+- **Annotation CSVs** — `csv/{urn}.annotations.csv` for every score set that has
+  completed the mapping pipeline. Joins external-database annotations (Ensembl VEP
+  functional consequence, gnomAD v4.1 allele frequency, ClinGen Allele Registry ID)
+  with post-mapped HGVS (`g.`/`c.`/`p.` and assay-level) and the GA4GH VRS digest.
+- **Mapped-variant JSON** — `mapped/{urn}.mapped-variants.json` for every mapped
+  score set. Each record carries the pre-mapped and post-mapped VRS alleles, the
+  VRS schema version, the mapping API version, and the ClinGen allele ID, mirroring
+  `GET /api/v1/score-sets/{urn}/mapped-variants`.
+- **VA-Spec annotation NDJSON** — `va/{urn}.va.ndjson` for every mapped score set.
+  One line per current mapped variant carrying its highest materialized GA4GH
+  VA-Spec layer (study result → functional-impact statement → pathogenicity
+  statement), mirroring the `annotated-variants` streaming endpoints.
+- **ClinVar release columns** in the annotation CSVs, covering the `2015_02`
+  through `2026_01` annual snapshots.
+
+### Changed
+
+- **CSV columns are now namespaced.** Every column carries a source prefix
+  separated by a dot: score columns are `scores.*` (e.g. `scores.score`), counts
+  are `counts.*`, mapping-pipeline columns are `mavedb.*`, and external annotations
+  are `vep.*` / `gnomad.*` / `clingen.*`. Core identifier columns (`accession`,
+  `hgvs_nt`, `hgvs_pro`, `hgvs_splice`) remain unprefixed. **Consumers that parsed
+  earlier archives by bare column name (e.g. `score`) must update to the namespaced
+  names.**
+- **Cis-phased (haplotype) variants** are now combined into a single HGVS
+  expression in the CSV outputs where a combined expression can be derived.
+- Mapped-variant and VA-Spec outputs include only the **current** mapping for each
+  variant; superseded mappings are excluded.
+
+### Fixed
+
+- VA-Spec annotation output is now valid and round-trippable (it deserializes back
+  into GA4GH VA-Spec objects without loss).
+
+### Notes
+
+- Annotation, mapped-variant, and VA-Spec files are present **only** for score sets
+  that have completed the mapping pipeline. Unmapped score sets ship scores/counts
+  CSVs only, as before.
+- See `README.md` in this archive for the full file layout, column definitions, and
+  caveats.

--- a/src/mavedb/scripts/resources/README.md
+++ b/src/mavedb/scripts/resources/README.md
@@ -30,6 +30,7 @@ Unpublished data, private datasets, and datasets published under other licenses 
 ```
 mavedb-dump.YYYYMMDDHHMMSS.zip
 ├── README.md                                  # This file
+├── CHANGELOG.md                               # What changed between archive versions
 ├── LICENSE.txt                                # Creative Commons CC0 1.0 license text
 ├── main.json                                  # Metadata for all included datasets
 ├── csv/


### PR DESCRIPTION
This pull request adds a versioned changelog to the MaveDB public data dump archive and includes it in the exported data bundle. It also updates documentation to clarify the release process and the new file layout. The most important changes are:

**Changelog integration and release process:**

* Added a new `CHANGELOG.md` file in `src/mavedb/scripts/resources/` that documents changes between versions of the MaveDB public data archive published on Zenodo, starting with version 5. This changelog is now bundled inside every archive.
* Updated `export_public_data.py` to include `CHANGELOG.md` in the exported archive and updated the release instructions to require a changelog entry for every new version. [[1]](diffhunk://#diff-55aa9a60a74f165b55413b4a832e9a36edb337b304a0c608e96bafb705d9f532R14-R17) [[2]](diffhunk://#diff-55aa9a60a74f165b55413b4a832e9a36edb337b304a0c608e96bafb705d9f532L132-R140)

**Documentation and file layout:**

* Updated `README.md` in the archive to list `CHANGELOG.md` as part of the archive file structure.