### PR TITLE
build(dev): replace LocalStack with moto for local S3 emulation

### DIFF
--- a/bin/localstack-init.sh
+++ b/bin/localstack-init.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "Initializing local S3 bucket..."
-awslocal s3 mb s3://score-set-csv-uploads-dev
-echo "S3 bucket 'score-set-csv-uploads-dev' created."

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -103,17 +103,19 @@ services:
     volumes:
       - mavedb-redis-dev:/data
 
-  localstack:
-    image: localstack/localstack:latest
+  # AWS mock.
+  moto:
+    image: motoserver/moto:latest
     ports:
-      - "4566:4566"
-    env_file:
-      - settings/.env.dev
-    environment:
-      - SERVICES=s3:4566 # We only need S3 for MaveDB
-    volumes:
-      - mavedb-localstack-dev:/var/lib/localstack
-      - "./bin/localstack-init.sh:/etc/localstack/init/ready.d/localstack-init.sh"
+      - "5001:5000"
+
+  moto-init:
+    # One-shot: create the upload bucket once moto is up (moto has no auto-create).
+    # A raw PUT is all it takes; --retry-all-errors waits out moto's startup.
+    image: curlimages/curl:latest
+    depends_on:
+      - moto
+    command: -sf --retry 10 --retry-all-errors --retry-delay 1 -X PUT http://moto:5000/score-set-csv-uploads-dev
 
   seqrepo:
     image: biocommons/seqrepo:2024-12-20
@@ -124,4 +126,3 @@ volumes:
   mavedb-data-dev:
   mavedb-redis-dev:
   mavedb-seqrepo-dev:
-  mavedb-localstack-dev:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,6 +10,7 @@ services:
     depends_on:
       - db
       - redis
+      - moto-init
     env_file:
       - settings/.env.dev
     environment:
@@ -54,6 +55,7 @@ services:
     depends_on:
       - db
       - redis
+      - moto-init
 
   dcd-mapping:
     build: ../dcd_mapping

--- a/settings/.env.template
+++ b/settings/.env.template
@@ -105,7 +105,7 @@ GNOMAD_DATA_VERSION=v4.1
 
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
-S3_ENDPOINT_URL=http://localstack:4566
+S3_ENDPOINT_URL=http://moto:5000
 UPLOAD_S3_BUCKET_NAME=score-set-csv-uploads-dev
 
 ####################################################################################################


### PR DESCRIPTION
## Summary
Replaces LocalStack with moto for local S3 emulation. LocalStack archived its Community edition in March 2026 and moved S3 behind a paid token, so `docker compose up` fails with auth errors for anyone pulling the current image.

## Why moto (not S3Mock or Floci)
- **Adobe S3Mock** is Java-SDK-first: every boto3 `PutObject` fails against it (tested 4.6.0 and 5.2.0) because its expect-100-continue handshake drops the connection. It would require path-style + Expect workarounds in our shared `s3_client()` — which also serves production.
- **moto** (Apache-2.0) is built for boto3 and runs the CSV upload/download flow with an unmodified client. It's also multi-service, leaving room for e.g. local Secrets Manager later without another migration.
- **Floci/MiniStack/kumo** are young multi-service LocalStack clones — more than we need, less proven with boto3.

## Changes
- `docker-compose-dev.yml`: `localstack` → `moto` + one-shot `moto-init` (`curlimages/curl`) that PUTs the upload bucket once moto is up.
- Deleted `bin/localstack-init.sh` (and the `awslocal` dependency).
- `settings/.env.template`: `S3_ENDPOINT_URL=http://moto:5000`.
- Host port published as `5001:5000`.
- No production code changed; unit tests already mock the S3 client directly.