### PR TITLE
fix: return 4XX for malformed input to hgvs/validate

### DIFF
--- a/src/mavedb/routers/hgvs.py
+++ b/src/mavedb/routers/hgvs.py
@@ -5,10 +5,11 @@ import hgvs.dataproviders.uta
 from cdot.hgvs.dataproviders import RESTDataProvider
 from fastapi import APIRouter, Depends, HTTPException
 from hgvs import parser, validator
-from hgvs.exceptions import HGVSDataNotAvailableError, HGVSInvalidVariantError
+from hgvs.exceptions import HGVSDataNotAvailableError, HGVSError
 
 from mavedb.deps import hgvs_data_provider
-from mavedb.routers.shared import BASE_400_RESPONSE, PUBLIC_ERROR_RESPONSES, ROUTER_BASE_PREFIX
+from mavedb.routers.shared import PUBLIC_ERROR_RESPONSES, ROUTER_BASE_PREFIX, VALIDATION_ERROR_RESPONSES
+from mavedb.view_models.hgvs import HgvsValidationRequest
 
 TAG_NAME = "Transcripts"
 
@@ -44,22 +45,23 @@ def hgvs_fetch(accession: str, hdp: RESTDataProvider = Depends(hgvs_data_provide
     "/validate",
     status_code=200,
     response_model=bool,
-    responses={**BASE_400_RESPONSE},
+    responses={**VALIDATION_ERROR_RESPONSES},
     summary="Validate a provided variant",
 )
-def hgvs_validate(variant: dict[str, str], hdp: RESTDataProvider = Depends(hgvs_data_provider)) -> bool:
+def hgvs_validate(request: HgvsValidationRequest, hdp: RESTDataProvider = Depends(hgvs_data_provider)) -> bool:
     """
     Validate the provided HGVS variant string.
+
+    Parsing and validation failures both stem from caller-supplied input, so any ``HGVSError`` — a syntactic
+    parse failure, an inconsistent variant, an unknown accession — is surfaced as a 400 rather than escaping
+    to the catch-all 500 handler.
     """
     hp = parser.Parser()
-    variant_hgvs = hp.parse(variant["variant"])
-
     try:
-        valid = validator.Validator(hdp=hdp).validate(variant_hgvs, strict=False)
-    except HGVSInvalidVariantError as e:
+        variant_hgvs = hp.parse(request.variant)
+        return validator.Validator(hdp=hdp).validate(variant_hgvs, strict=False)
+    except HGVSError as e:
         raise HTTPException(400, str(e))
-    else:
-        return valid
 
 
 @router.get("/assemblies", status_code=200, response_model=list[str], summary="List stored assemblies")

--- a/src/mavedb/view_models/hgvs.py
+++ b/src/mavedb/view_models/hgvs.py
@@ -1,0 +1,5 @@
+from mavedb.view_models.base.base import BaseModel
+
+
+class HgvsValidationRequest(BaseModel):
+    variant: str

--- a/tests/routers/test_hgvs.py
+++ b/tests/routers/test_hgvs.py
@@ -24,6 +24,7 @@ VALID_TRANSCRIPT = "NM_001408458.1"
 INVALID_TRANSCRIPT = "NX_99999.1"
 VALID_VARIANT = VALID_NT_ACCESSION + ":c.1G>A"
 INVALID_VARIANT = VALID_NT_ACCESSION + ":c.1delA"
+UNPARSEABLE_VARIANT = "not a valid hgvs string"
 HAS_PROTEIN_ACCESSION = "NM_000014.4"
 PROTEIN_ACCESSION = "NP_000005.2"
 
@@ -62,6 +63,21 @@ def test_hgvs_validate_invalid(client, setup_router_db):
 
         assert response.status_code == 400
         assert "does not agree" in response.json()["detail"]
+
+
+def test_hgvs_validate_unparseable(client, setup_router_db):
+    # A syntactically invalid HGVS string fails at the parse stage, before validation. This is a caller
+    # error and must surface as a 400 rather than escaping to the catch-all 500 handler.
+    payload = {"variant": UNPARSEABLE_VARIANT}
+    response = client.post("/api/v1/hgvs/validate", json=payload)
+
+    assert response.status_code == 400
+
+
+def test_hgvs_validate_missing_field(client, setup_router_db):
+    response = client.post("/api/v1/hgvs/validate", json={})
+
+    assert response.status_code == 422
 
 
 def test_hgvs_list_assemblies(client, setup_router_db):


### PR DESCRIPTION
## Summary

`POST /api/v1/hgvs/validate` returned 500 (and fired a Slack alert) for malformed input. This makes caller-input failures return 4XX instead.

## What changed

- **Parse inside the error handler.** `hp.parse()` previously ran outside the `try`/`except`, so an `HGVSParseError` on an unparseable variant string escaped to the catch-all 500 handler. The parse now runs inside the handler, which catches the base class `HGVSError` and returns a **400**.
- **Typed request body.** Replaced the free-form `variant: dict[str, str]` body with a new `HgvsValidationRequest` view model (`variant: str`). A missing/mistyped field now returns **422** automatically, and the request schema is self-documenting in OpenAPI.
- **Docs.** Endpoint `responses` updated from the 400-only set to `VALIDATION_ERROR_RESPONSES` (400 + 422).

## Testing

- Added `test_hgvs_validate_unparseable` (asserts 400) and `test_hgvs_validate_missing_field` (asserts 422).