### PR TITLE
fix(logging): record the complete request path for variant endpoints

### DIFF
--- a/src/mavedb/lib/logging/context.py
+++ b/src/mavedb/lib/logging/context.py
@@ -23,7 +23,10 @@ class PopulatedRawContextMiddleware(RawContextMiddleware):
         ctx: dict[str, Any] = {}
 
         ctx["request_ns"] = time.time_ns()
-        ctx["path"] = request.url.path
+        # The ASGI scope rather than request.url.path, which truncates at a '#'. Starlette builds
+        # request.url by re-parsing, so a variant URN's '#' opens a fragment there and the variant
+        # number and sub-resource are dropped: three /variants routes all logged the same path.
+        ctx["path"] = request.scope["path"]
 
         if isinstance(request, Request):
             ctx["method"] = request.method


### PR DESCRIPTION
This pull request updates how the request path is logged in the context for incoming requests. Instead of using `request.url.path`, which could incorrectly truncate paths at the `#` character, it now uses the ASGI scope's `path` directly to ensure the full path is captured. This change addresses an issue where different `/variants` routes were being logged as the same path.

Logging improvements:

* Updated the `set_context` method in `context.py` to use `request.scope["path"]` instead of `request.url.path` for more accurate logging of request paths, especially for variant URNs containing `#` characters.
